### PR TITLE
Move a project's encrypted issue IDs to a lookup table

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -7,13 +7,13 @@ class Project < ApplicationRecord
 
   belongs_to :account
   has_one :project_setting
+  has_many :project_issues
 
   before_create :set_slug
   after_create :make_settings
 
   def issues
-    decrypted_issue_ids = self.issues_encrypted_ids.map{ |id| EncryptionService.decrypt(id) }
-    @issues ||= Issue.where(id: decrypted_issue_ids)
+    @issues ||= ProjectIssue.issues_for_project(self.id)
   end
 
   def to_param

--- a/app/models/project_issue.rb
+++ b/app/models/project_issue.rb
@@ -1,0 +1,24 @@
+class ProjectIssue < ApplicationRecord
+
+  belongs_to :project
+
+  validates_presence_of :issue_encrypted_id
+  validates_uniqueness_of :issue_encrypted_id
+
+  before_create :encrypt_issue_id
+
+  attr_accessor :issue_id
+
+  def self.issues_for_project(project_id)
+    encrypted_issue_ids = where(project_id: project_id).pluck(:issue_encrypted_id)
+    issue_ids = encrypted_issue_ids.map{ |id| EncryptionService.decrypt(id) }
+    Issue.where(id: issue_ids)
+  end
+
+  private
+
+  def encrypt_issue_id
+    self.issue_encrypted_id = EncryptionService.encrypt(issue_id)
+  end
+
+end

--- a/db/migrate/20190113181453_create_projects_issues.rb
+++ b/db/migrate/20190113181453_create_projects_issues.rb
@@ -1,0 +1,9 @@
+class CreateProjectsIssues < ActiveRecord::Migration[5.2]
+  def change
+    create_table :project_issues, id: :uuid do |t|
+      t.references :project, type: :uuid, foreign_key: true
+      t.string :issue_encrypted_id, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190113190327_drop_encrypted_issue_ids_from_project.rb
+++ b/db/migrate/20190113190327_drop_encrypted_issue_ids_from_project.rb
@@ -1,0 +1,10 @@
+class DropEncryptedIssueIdsFromProject < ActiveRecord::Migration[5.2]
+  def up
+    remove_column :projects, :issues_encrypted_ids
+  end
+
+  def down
+    add_column :projects, :issues_encrypted_ids, :text, default: [], array: true
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_06_013142) do
+ActiveRecord::Schema.define(version: 2019_01_13_190327) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -92,6 +92,14 @@ ActiveRecord::Schema.define(version: 2019_01_06_013142) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "project_issues", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "project_id"
+    t.string "issue_encrypted_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["project_id"], name: "index_project_issues_on_project_id"
+  end
+
   create_table "project_settings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "paused_at"
     t.integer "rate_per_day", default: 5
@@ -115,7 +123,6 @@ ActiveRecord::Schema.define(version: 2019_01_06_013142) do
     t.uuid "account_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "issues_encrypted_ids", default: [], array: true
     t.index ["account_id"], name: "index_projects_on_account_id"
     t.index ["slug"], name: "index_projects_on_slug", unique: true
   end
@@ -123,6 +130,7 @@ ActiveRecord::Schema.define(version: 2019_01_06_013142) do
   add_foreign_key "issue_comments", "issues"
   add_foreign_key "issue_events", "issues"
   add_foreign_key "issue_logs", "issues"
+  add_foreign_key "project_issues", "projects"
   add_foreign_key "project_settings", "projects"
   add_foreign_key "projects", "accounts"
 end

--- a/spec/models/projects_issue_spec.rb
+++ b/spec/models/projects_issue_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ProjectsIssue, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## Problem
We were storing the encrypted issue IDs in an array on the Projects table, which would lead to bloat for a project with lots of issues.

## Solution
Introduce a lookup table.