### PR TITLE
Permissions on issue comment creation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,7 @@ Style/StringLiterals:
   Enabled: false
 
 Layout/SpaceBeforeBlockBraces:
-  EnforcedStyle: no_space
+  Enabled: false
 
 Style/SymbolArray:
   EnforcedStyle: brackets
@@ -44,3 +44,10 @@ Metrics/MethodLength:
 
 Metrics/AbcSize:
   Enabled: false
+
+Layout/EmptyLinesAroundBlockBody:
+  Enabled: false
+
+Metrics/BlockLength:
+  Enabled: false
+

--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ end
 group :test do
   gem 'capybara', '>= 2.15'
   gem 'chromedriver-helper'
+  gem 'factory_bot'
   gem 'selenium-webdriver'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,8 @@ GEM
       railties (>= 3.2, < 6.0)
     erubi (1.8.0)
     execjs (2.7.0)
+    factory_bot (4.11.1)
+      activesupport (>= 3.0.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
@@ -351,6 +353,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   devise
   dotenv-rails
+  factory_bot
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)

--- a/app/controllers/issue_comments_controller.rb
+++ b/app/controllers/issue_comments_controller.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 class IssueCommentsController < ApplicationController
-  before_action :scope_project_and_issue
+  before_action :scope_project
+  before_action :scope_issue
 
   def create
+    render(status: :forbidden, plain: nil) && return unless @issue.account_can_comment?(current_account)
     comment = IssueComment.new(issue_id: @issue.id, commenter_id: current_account.id)
     comment.visible_to_reporter = comment_params[:visible_to_reporter] == '1'
     comment.visible_to_respondent = comment_params[:visible_to_respondent] == '1'
@@ -18,8 +20,12 @@ class IssueCommentsController < ApplicationController
     params.require(:issue_comment).permit(:text, :visible_to_reporter, :visible_to_respondent)
   end
 
-  def scope_project_and_issue
+  def scope_project
     @project = Project.find_by(slug: params[:project_slug])
+  end
+
+  def scope_issue
     @issue = Issue.find(params[:issue_id])
   end
+
 end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -37,6 +37,12 @@ class Issue < ApplicationRecord
     end
   end
 
+  def account_can_comment?(account)
+    return true if project.account == account
+    return true if reporter == account
+    return true if respondent == account
+  end
+
   def open?
     OPEN_STATUSES.include?(self.aasm_state)
   end

--- a/spec/controllers/issue_comments_controller_spec.rb
+++ b/spec/controllers/issue_comments_controller_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe IssueCommentsController, type: :controller do
+
+  describe "#create" do
+
+    let(:reporter)    { Account.new(confirmed_at: Time.zone.now) }
+    let(:moderator)   { Account.new(confirmed_at: Time.zone.now) }
+    let(:respondent)  { Account.new(confirmed_at: Time.zone.now) }
+    let(:rando)       { Account.new(confirmed_at: Time.zone.now) }
+    let(:project)     { Project.new(id: SecureRandom.uuid, slug: "sample-project", account: moderator) }
+    let(:issue)       { Issue.new(id: SecureRandom.uuid) }
+
+    before do
+      allow(Project).to receive(:find_by).and_return(project)
+      allow(Issue).to receive(:find).and_return(issue)
+      allow(issue).to receive(:project).and_return(project)
+      allow(issue).to receive(:reporter).and_return(reporter)
+      allow(issue).to receive(:respondent).and_return(respondent)
+    end
+
+    context "permissions" do
+
+      it "allows a moderator to make a comment" do
+        controller.sign_in(moderator, scope: :account)
+        post :create, params: {
+          project_slug: project.slug,
+          issue_id: 1,
+          issue_comment: { text: "This sure is a comment." }
+        }
+        expect(response).to have_http_status 302
+      end
+
+      it "allows a reporter to make a comment" do
+        controller.sign_in(reporter, scope: :account)
+        post :create, params: {
+          project_slug: project.slug,
+          issue_id: 1,
+          issue_comment: { text: "This sure is a comment." }
+        }
+        expect(response).to have_http_status 302
+      end
+
+      it "allows a respondent to make a comment" do
+        controller.sign_in(respondent)
+        post :create, params: {
+          project_slug: project.slug,
+          issue_id: 1,
+          issue_comment: { text: "This sure is a comment." }
+        }
+        expect(response).to have_http_status 302
+      end
+
+      it "blocks an unaffiliated account from making a comment" do
+        controller.sign_in(rando, scope: :account)
+        post :create, params: {
+          project_slug: project.slug,
+          issue_id: 1,
+          issue_comment: { text: "This sure is a comment." }
+        }
+        expect(response).to have_http_status 403
+      end
+
+    end
+  end
+
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,6 +2,8 @@
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
+require 'devise'
+
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
@@ -36,6 +38,9 @@ RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
+  config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include Devise::Test::ControllerHelpers, type: :view
+  config.include FactoryBot::Syntax::Methods
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.


### PR DESCRIPTION
## Problem
We needed to tighten controls on who could create comments on issues.

## Solution
Introduce an `account_can_comment?` method.