### PR TITLE
Default consequence ladder

### DIFF
--- a/app/models/issue_severity_level.rb
+++ b/app/models/issue_severity_level.rb
@@ -1,13 +1,43 @@
 class IssueSeverityLevel < ApplicationRecord
 
-  belongs_to :project
+  belongs_to :project, optional: true
   has_many :issues
 
   default_scope { order("severity ASC") }
+  scope :beacon_defaults, -> { where(scope: "template") }
 
   validates_presence_of :scope, :label, :severity, :example, :consequence
   validates_uniqueness_of :severity, scope: :project
 
-  SCOPES = %w{project organization example}.freeze
+  def self.clone_from_template_for_project(project)
+    project.issues.each{ |issue| issue.update_attribute(:issue_severity_level_id, nil) }
+    project.issue_severity_levels.destroy_all
+    beacon_defaults.each do |default|
+      project.issue_severity_levels.create(
+        severity: default.severity,
+        label: default.label,
+        example: default.example,
+        consequence: default.consequence
+      )
+    end
+  end
+
+  def self.clone_from_existing_project(source:, target:)
+    target.issues.each{ |issue| issue.update_attribute(:issue_severity_level_id, nil) }
+    target.issue_severity_levels.destroy_all
+    source.issue_severity_levels.each do |default|
+      target.issue_severity_levels.create(
+        severity: default.severity,
+        label: default.label,
+        example: default.example,
+        consequence: default.consequence
+      )
+    end
+  end
+
+  def can_be_safely_destroyed?
+    return false if project.issues.where(issue_severity_level_id: self.severity).any?
+    true
+  end
 
 end

--- a/app/models/issue_severity_level.rb
+++ b/app/models/issue_severity_level.rb
@@ -36,7 +36,7 @@ class IssueSeverityLevel < ApplicationRecord
   end
 
   def can_be_safely_destroyed?
-    return false if project.issues.where(issue_severity_level_id: self.severity).any?
+    return false if project.issues.where(issue_severity_level_id: self.id).any?
     true
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -12,6 +12,8 @@ class Project < ApplicationRecord
   before_create :set_slug
   after_create :make_settings
 
+  attr_accessor :consequence_ladder_default_source
+
   def issues
     @issues ||= ProjectIssue.issues_for_project(id)
   end

--- a/app/views/issue_severity_levels/_consequence.html.erb
+++ b/app/views/issue_severity_levels/_consequence.html.erb
@@ -6,7 +6,7 @@
       <h5>Consequence</h5>
       <p><%= consequence.consequence %></p>
       <% if current_account.can_manage_consequence_ladder?(@project) %>
-        <a onmouseup="toggle_show_and_form_views('consequence-<%= consequence.severity %>')">Edit</a>
+        <a onclick="toggle_show_and_form_views('consequence-<%= consequence.severity %>')">Edit</a>
       <% end %>
     </div>
   </div>
@@ -39,6 +39,9 @@
 
           <div class="actions">
             <%= f.submit "Save", class: "btn btn-primary" %>
+            <% if consequence.can_be_safely_destroyed? %>
+             <%= f.submit "Delete", class: "btn btn-danger" %>
+            <% end %>
             <a onclick="toggle_show_and_form_views('consequence-<%= consequence.severity %>')" class="btn">Cancel</a>
           </div>
         <% end %>

--- a/app/views/issue_severity_levels/index.html.erb
+++ b/app/views/issue_severity_levels/index.html.erb
@@ -1,41 +1,61 @@
 <h2><%= link_to @project.name, @project %>: Consequence Ladder</h2>
 
+<div class="mb-3" style="border-bottom: 1px solid #ddd">
+  <p>The consequence ladder establishes guidelines for how you will enforce your code of conduct, specifying different escalating levels of violations and their consequences. When your project is public, its ladder will be displayed on your project's directory page. As part of moderation of issues, you will be able to assign a level to the issue, and this level's description will be visible to both reporters and respondents.</p>
+
+  <p>You can customize your consequence ladder from Beacon defaults or another one of your projects, or create your own.</p>
+
+  <p><b>Important:</b> If you clone the consequence ladder from another source, all of your current issues will lose their associated severity.</p>
+
+  <%= form_for @project, url: project_clone_ladder_path(slug: @project.slug) do |f| %>
+    <div class="form-group col-sm-6">
+      <%= f.label :clone_from %>
+      <%= f.select :consequence_ladder_default_source, @available_ladders.map(&:titleize), class: "form-control", include_blank: "Select..." %>
+    </div>
+
+    <div class="actions mb-3">
+      <%= f.submit "Clone", class: "btn btn-primary" %>
+    </div>
+  <% end %>
+
+</div>
+
 <div class="row">
 
   <div class="col">
-    <% @issue_severity_levels.each do |consequence| %>
-      <%= render partial: "consequence", locals: { consequence: consequence } %>
-    <% end %>
+    <div id="ladder"%>
+      <% @issue_severity_levels.each do |consequence| %>
+        <%= render partial: "consequence", locals: { consequence: consequence } %>
+      <% end %>
+    </div>
   </div>
 
   <div class="col">
-    <% if current_account.can_manage_consequence_ladder?(@project) %>
-      <h3>New Consequence</h4>
-      <%= form_for @issue_severity_level, url: project_issue_severity_levels_path(@project) do |f| %>
-        <div class="form-group col-sm-6">
-          <%= f.label :label %><br />
-          <%= f.text_field :label, autofocus: true, class: "form-control" %>
-        </div>
+    <h3>New Consequence</h4>
+    <%= form_for @issue_severity_level, url: project_issue_severity_levels_path do |f| %>
+      <div class="form-group col-sm-6">
+        <%= f.label :label %><br />
+        <%= f.text_field :label, autofocus: true, class: "form-control" %>
+      </div>
 
-        <div class="form-group col-sm-6">
-          <%= f.label :severity %>
-          <%= f.select :severity, @available_severities, class: "form-control" %>
-        </div>
+      <div class="form-group col-sm-6">
+        <%= f.label :severity %>
+        <%= f.select :severity, @available_severities, class: "form-control" %>
+      </div>
 
-        <div class="form-group col-sm-6">
-          <%= f.label :example %><br />
-          <%= f.text_area :example, class: "form-control" %>
-        </div>
+      <div class="form-group col-sm-6">
+        <%= f.label :example %><br />
+        <%= f.text_area :example, class: "form-control" %>
+      </div>
 
-        <div class="form-group col-sm-6">
-          <%= f.label :consequence %><br />
-          <%= f.text_area :consequence, class: "form-control" %>
-        </div>
+      <div class="form-group col-sm-6">
+        <%= f.label :consequence %><br />
+        <%= f.text_area :consequence, class: "form-control" %>
+      </div>
 
-        <div class="actions">
-          <%= f.submit "Update Ladder", class: "btn btn-primary" %>
-        </div>
-      <% end %>
+      <div class="actions">
+        <%= f.submit "Update Ladder", class: "btn btn-primary" %>
+      </div>
     <% end %>
   </div>
 </div>

--- a/app/views/issues/_moderator_view.html.erb
+++ b/app/views/issues/_moderator_view.html.erb
@@ -44,6 +44,7 @@
         <li>
           <div id="severity-show" style="display: <%= @issue_severity_level.present? ? 'block' : 'none' %>">
             <%= "#{@issue_severity_level.try(:severity)} (#{@issue_severity_level.try(:label)})" %>
+            <p><%= "#{@issue_severity_level.try(:consequence)}" %></p>
             <button type="button" class="btn btn-primary btn-sm" onmouseup="toggle_show_and_form_views('severity')">Edit</button>
           </div>
           <div id="severity-form" style="display: <%= @issue_severity_level.present? ? 'none' : 'block' %>">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,10 +14,10 @@ Rails.application.routes.draw do
 
   resources :projects, param: :slug do
     resources :issue_severity_levels
+    patch "clone_ladder", to: "projects#clone_ladder"
     resources :issues do
       resources :issue_comments, only: [:create, :new]
       resources :issue_invitations, only: [:create, :new]
-      post "upload", to: "issues#upload"
       post "acknowledge", to: "issues#acknowledge"
       post "dismiss", to: "issues#dismiss"
       patch "resolve", to: "issues#resolve"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,31 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+IssueSeverityLevel.create(
+  scope: "template",
+  severity: 1,
+  label: "Correction",
+  example: "Use of inappropriate language, such as profanity, or other behavior deemed unprofessional or unwelcome in the community.",
+  consequence: "A private, written warning from project leadership, with clarity of violation and explanation of why the behavior was inappropriate."
+)
+
+IssueSeverityLevel.create(
+  scope: "template",
+  severity: 2,
+  label: "Warning",
+  example: "A violation through a single incident or series of actions that create toxicity in the community.",
+  consequence: "A warning with consequences of continued behavior. No interaction with people involved, including unsolicited interaction with those enforcing the guidelines, for a period specified by moderators. This includes avoiding interactions in any project space, as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban."
+)
+
+IssueSeverityLevel.create(
+  scope: "template",
+  severity: 3,
+  label: "Temporary Ban",
+  example: "A serious violation of community standards, including sustained inappropriate behavior or language, or targeting/harassing an individual.",
+  consequence: "A temporary ban from any sort of interaction in the project community, including pull requests, issues, and comments, for a period specified by moderators. No interaction with people involved, including unsolicited interaction with those enforcing the guidelines, during this period. This includes avoiding interactions in any project space, as well as external channels like social media. Violating these terms may lead to a permanent ban."
+)
+
+IssueSeverityLevel.create(
+  scope: "template",
+  severity: 4,
+  label: "Permanent Ban",
+  example: "Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior or language,  harassment of an individual, or aggression or disparagement of class of individuals.",
+  consequence: "A permanent ban from any sort of interaction in the project community, including pull requests, issues, and comments, for a period specified by moderators."
+)


### PR DESCRIPTION
All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

## Problem
Project moderators may need a starting point for their consequence ladder.

## Solution
Give them the ability to clone system defaults or use another one of their projects as a source.

## Todo
- [ ] Migrate database
- [ ] Seed database

## Notes for Reviewers
Anything that you want to tell the people who are going to review your pull request.

## Checklist
- [ ] Reasonable and adequate test coverage
- [x] Requires a database migration
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`
