### PR TITLE
Refactor notifications to not lead issue <> account

### DIFF
--- a/app/controllers/account_project_blocks_controller.rb
+++ b/app/controllers/account_project_blocks_controller.rb
@@ -29,7 +29,7 @@ class AccountProjectBlocksController < ApplicationController
   end
 
   def destroy
-    @project.account_project_blocks.find{ |block| block.account_id = block_params[:account_id]).destroy
+    @project.account_project_blocks.find{ |block| block.account_id = block_params[:account_id] }.destroy
     if params[:return_to] == "respondent"
       redirect_to project_respondent_url(@project, id: block.account_id)
     elsif params[:return_to] == "reporter"

--- a/app/controllers/account_project_blocks_controller.rb
+++ b/app/controllers/account_project_blocks_controller.rb
@@ -29,12 +29,11 @@ class AccountProjectBlocksController < ApplicationController
   end
 
   def destroy
-    account = Account.find(block_params[:account_id])
-    @project.account_project_blocks.find_by(account_id: account.id).destroy
+    @project.account_project_blocks.find{ |block| block.account_id = block_params[:account_id]).destroy
     if params[:return_to] == "respondent"
-      redirect_to project_respondent_url(@project, id: account.id)
+      redirect_to project_respondent_url(@project, id: block.account_id)
     elsif params[:return_to] == "reporter"
-      redirect_to project_reporter_url(@project, id: account.id)
+      redirect_to project_reporter_url(@project, id: block.account_id)
     else
       redirect_to project_account_project_blocks_url(@project)
     end
@@ -51,7 +50,7 @@ class AccountProjectBlocksController < ApplicationController
   end
 
   def scope_project
-    @project = Project.find_by(slug: params[:project_slug])
+    @project = Project.where(slug: params[:project_slug]).includes(:account_project_blocks)
   end
 
 end

--- a/app/controllers/issue_comments_controller.rb
+++ b/app/controllers/issue_comments_controller.rb
@@ -34,7 +34,7 @@ class IssueCommentsController < ApplicationController
   end
 
   def scope_project
-    @project = Project.find_by(slug: params[:project_slug])
+    @project = Project.where(slug: params[:project_slug]).includes(:account).first
   end
 
   def scope_issue
@@ -61,29 +61,29 @@ class IssueCommentsController < ApplicationController
     if @project.moderator?(current_account) && visible_to_reporter?
       email = @issue.reporter.email
       commenter_kind = "moderator"
-      NotificationService.notify(project: @project, issue: @issue, issue_comment: @comment, account: @issue.reporter)
+      NotificationService.notify(account: @issue.reporter, project: @project, issue_id: @issue.id, issue_comment_id: @comment.id)
     elsif @project.moderator?(current_account) && visible_to_respondent?
       email = @issue.respondent.email
       commenter_kind = "moderator"
-      NotificationService.notify(project: @project, issue: @issue, issue_comment: @comment, account: @issue.respondent)
+      NotificationService.notify(account: @issue.respondent, project_id: @project.id, issue_id: @issue.id, issue_comment_id: @comment.id)
     elsif @comment.commenter == @issue.reporter
       email = @project.moderator_emails
       commenter_kind = "reporter"
       @project.moderators.each do |moderator|
-        NotificationService.notify(project: @project, issue: @issue, issue_comment: @comment, account: moderator)
+        NotificationService.notify(account: moderator, project_id: @project.id, issue_id: @issue.id, issue_comment_id: @comment.id)
       end
     elsif @comment.commenter == @issue.respondent
       email = @project.moderator_emails
       commenter_kind = "respondent"
       @project.moderators.each do |moderator|
-        NotificationService.notify(project: @project, issue: @issue, issue_comment: @comment, account: moderator)
+        NotificationService.notify(account: moderator, project_id: @project.id, issue_id: @issue.id, issue_comment_id: @comment.id)
       end
     else
       email = @project.moderator_emails
       commenter_kind = "moderator"
       @project.moderators.each do |moderator|
         next if moderator == current_account
-        NotificationService.notify(project: @project, issue: @issue, issue_comment: @comment, account: moderator)
+        NotificationService.notify(account: moderator, project_id: @project.id, issue_id: @issue.id, issue_comment_id: @comment.id)
       end
     end
 

--- a/app/controllers/issue_invitations_controller.rb
+++ b/app/controllers/issue_invitations_controller.rb
@@ -20,6 +20,8 @@ class IssueInvitationsController < ApplicationController
         email: account.email,
         project_name: @issue.project.name
       ).notify_existing_account_of_issue.deliver_now
+      AccountIssue.create(issue_id: @issue.id, account: account)
+      NotificationService.notify(account: account, project_id: @project.id, issue_id: @issue.id)
       @issue.update_attribute(:respondent_encrypted_id, EncryptionService.encrypt(account.id))
     else
       IssueInvitation.create(

--- a/app/controllers/issue_severity_levels_controller.rb
+++ b/app/controllers/issue_severity_levels_controller.rb
@@ -48,7 +48,7 @@ class IssueSeverityLevelsController < ApplicationController
   end
 
   def scope_project
-    @project = Project.find_by(slug: params[:project_slug])
+    @project = Project.where(slug: params[:project_slug]).includes(:issue_severity_levels).first
     @issue_severity_levels = @project.issue_severity_levels
     @available_severities = (1..10).to_a - @issue_severity_levels.map(&:severity)
   end

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -122,11 +122,11 @@ class IssuesController < ApplicationController
 
   def notify_on_new_issue
     @project.moderators.each do |moderator|
-      NotificationService.notify(project: @project, issue: @issue, account: moderator)
+      NotificationService.notify(account: moderator, project_id: @project.id, issue_id: @issue.id)
     end
     IssueNotificationsMailer.with(
       email: @project.moderator_emails,
-      project: @issue.project,
+      project: @project,
       issue: @issue
     ).notify_of_new_issue.deliver_now
   end
@@ -148,12 +148,11 @@ class IssuesController < ApplicationController
   end
 
   def scope_issue
-    @issue = Issue.find_by(id: params[:id])
-    @issue ||= Issue.find_by(id: params[:issue_id])
+    @issue = Issue.where(id: [params[:id], params[:issue_id]]).includes(:issue_comments).first
   end
 
   def scope_project
-    @project = Project.find_by(slug: params[:project_slug])
+    @project = Project.where(slug: params[:project_slug]).includes(:account).first
   end
 
 end

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -152,7 +152,7 @@ class IssuesController < ApplicationController
   end
 
   def scope_project
-    @project = Project.where(slug: params[:project_slug]).includes(:account).first
+    @project = Project.find_by(slug: params[:project_slug])
   end
 
 end

--- a/app/controllers/project_settings_controller.rb
+++ b/app/controllers/project_settings_controller.rb
@@ -30,7 +30,7 @@ class ProjectSettingsController < ApplicationController
   end
 
   def scope_project_and_settings
-    @project = Project.find_by(slug: params[:project_slug])
+    @project = Project.where(slug: params[:project_slug]).includes(:project_setting)
     @settings = @project.project_setting
   end
 

--- a/app/controllers/project_settings_controller.rb
+++ b/app/controllers/project_settings_controller.rb
@@ -30,7 +30,7 @@ class ProjectSettingsController < ApplicationController
   end
 
   def scope_project_and_settings
-    @project = Project.where(slug: params[:project_slug]).includes(:project_setting)
+    @project = Project.where(slug: params[:project_slug]).includes(:project_setting).first
     @settings = @project.project_setting
   end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -69,7 +69,7 @@ class ProjectsController < ApplicationController
   end
 
   def scope_project
-    @project = Project.find_by(slug: params[:slug])
+    @project = Project.where(slug: params[:slug]).joins(:project_setting).first
     @settings = @project.project_setting
     @issues = @project.issues
   end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -69,7 +69,7 @@ class ProjectsController < ApplicationController
   end
 
   def scope_project
-    @project = Project.where(slug: params[:slug]).joins(:project_setting).first
+    @project = Project.find_by(slug: params[:slug])
     @settings = @project.project_setting
     @issues = @project.issues
   end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -17,7 +17,6 @@ class Account < ApplicationRecord
   has_many :projects
   has_many :account_issues
   has_many :account_project_blocks
-  has_many :notifications
 
   before_validation :normalize_email
   before_create :hash_email
@@ -29,6 +28,10 @@ class Account < ApplicationRecord
 
   def issues
     @issues ||= AccountIssue.issues_for_account(id)
+  end
+
+  def notifications
+    @notifications ||= Notification.notifications_for_account(self)
   end
 
   private

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,12 +1,17 @@
 class Notification < ApplicationRecord
-  belongs_to :account
+
   belongs_to :project
   belongs_to :issue
   belongs_to :issue_comment, optional: true
 
   scope :with_project, -> { where("project_id IS NOT NULL") }
-  scope :with_issue, -> { where("issue_id IS NOT NULL") }
-  scope :with_comment, -> { where("issue_comment_id IS NOT NULL") }
-  scope :for_project, ->(project_id) { where(project_id: project_id) }
-  scope :for_issue, ->(issue_id) { where(issue_id: issue_id) }
+  scope :with_issue,   -> { where("issue_id IS NOT NULL") }
+  scope :with_comment,   -> { where("issue_comment_id IS NOT NULL") }
+  scope :for_project,  -> (project_id) { where(project_id: project_id) }
+  scope :for_issue,    -> (issue_id) { where(issue_id: issue_id) }
+
+  def self.notifications_for_account(account)
+    where(id: account.notification_encrypted_ids.map{ |id| EncryptionService.decrypt(id) })
+  end
+
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -5,10 +5,10 @@ class Notification < ApplicationRecord
   belongs_to :issue_comment, optional: true
 
   scope :with_project, -> { where("project_id IS NOT NULL") }
-  scope :with_issue,   -> { where("issue_id IS NOT NULL") }
-  scope :with_comment,   -> { where("issue_comment_id IS NOT NULL") }
-  scope :for_project,  -> (project_id) { where(project_id: project_id) }
-  scope :for_issue,    -> (issue_id) { where(issue_id: issue_id) }
+  scope :with_issue, -> { where("issue_id IS NOT NULL") }
+  scope :with_comment, -> { where("issue_comment_id IS NOT NULL") }
+  scope :for_project, ->(project_id) { where(project_id: project_id) }
+  scope :for_issue, ->(issue_id) { where(issue_id: issue_id) }
 
   def self.notifications_for_account(account)
     where(id: account.notification_encrypted_ids.map{ |id| EncryptionService.decrypt(id) })

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -67,7 +67,7 @@ class Project < ApplicationRecord
   private
 
   def set_slug
-    self.slug = name.downcase.gsub(/^[a-zA-Z0-9]/,'_')
+    self.slug = name.downcase.gsub(/^[a-zA-Z0-9]/, '_')
   end
 
   # TODO: Eventually this will inherit from an org's project template

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -67,7 +67,7 @@ class Project < ApplicationRecord
   private
 
   def set_slug
-    self.slug = name.downcase.tr(' ', '-')
+    self.slug = name.downcase.gsub(/^[a-zA-Z0-9]/,'_')
   end
 
   # TODO: Eventually this will inherit from an org's project template

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -1,12 +1,20 @@
 class NotificationService
 
-  def self.notify(project:, issue:, issue_comment: nil, account:)
-    Notification.create(
-      project_id: project.id,
-      issue_id: issue.id,
-      issue_comment_id: issue_comment.try(:id),
-      account_id: account.id
+  def self.notify(account:, project_id:, issue_id:, issue_comment_id: nil)
+    notification = Notification.create(
+      project_id: project_id,
+      issue_id: issue_id,
+      issue_comment_id: issue_comment_id
     )
+    account.notification_encrypted_ids << EncryptionService.encrypt(notification.id)
+    account.save
+  end
+
+  def self.notified!(account, notification_encrypted_id)
+    notification = Notification.find(EncryptionService.decrypt(notification_encrypted_id))
+    notification.destroy
+    account.notification_encrypted_ids.delete(notification_encrypted_id)
+    account.save
   end
 
 end

--- a/app/views/directory/index.html.erb
+++ b/app/views/directory/index.html.erb
@@ -2,7 +2,7 @@
 
 <% @projects.each_with_index do |project,i| %>
 
-  <% float_class = i < @projects.count - 1 ? "float-left" : "float-none" %>
+  <% float_class = i < @projects.size - 1 ? "float-left" : "float-none" %>
   <div class="card mb-3 mr-3 <%= float_class %>" style="width: 15rem; height: 15rem">
     <div class="card-body">
       <h5 class="card-title"><%= link_to project.name, directory_project_path(project.slug) %></h5>

--- a/app/views/issues/_cards.html.erb
+++ b/app/views/issues/_cards.html.erb
@@ -2,14 +2,14 @@
 
   <% issues.each_with_index do |issue,i| %>
 
-    <% float_class = i < issues.count - 1 ? "float-left" : "float-none" %>
+    <% float_class = i < issues.size - 1 ? "float-left" : "float-none" %>
     <div class="card mb-3 mr-3 <%= float_class %>" style="width: 15rem; height: 12rem">
       <div class="card-body">
         <h5 class="card-title"><%= issue.project.name %></h5>
         <div class="card-text">
           <p>
             <%= link_to "Issue ##{issue.issue_number}", project_issue_path(issue.project, issue) %>
-            <% count = current_account.notifications.for_issue(issue.id).count %>
+            <% count = current_account.notifications.for_issue(issue.id).size %>
             <% if count > 0 %>
               <span class="badge badge-pill badge-danger"><%= count %></span>
             <% end %>

--- a/app/views/issues/_moderator_view.html.erb
+++ b/app/views/issues/_moderator_view.html.erb
@@ -191,16 +191,18 @@
 
     <div class="tab-pane fade" id="nav-respondent-discussion" role="tabpanel" aria-labelledby="nav-respondent-discussion-tab">
 
-      <div class="card mb-3 mr-3" style="width: 100%">
-        <div class="card-body">
-          <h5 class="card-title">
-            Issue Summary to Respondent
-          </h5>
-          <div class="card-text">
-            <p><%= @issue.respondent_summary %></p>
+      <% if @issue.respondent_summary %>
+        <div class="card mb-3 mr-3" style="width: 100%">
+          <div class="card-body">
+            <h5 class="card-title">
+              Issue Summary to Respondent
+            </h5>
+            <div class="card-text">
+              <p><%= @issue.respondent_summary %></p>
+            </div>
           </div>
         </div>
-      </div>
+      <% end %>
 
       <div id="respondent-discussion">
         <% respondent_discussion_comments.each do |comment| %>

--- a/app/views/issues/index.html.erb
+++ b/app/views/issues/index.html.erb
@@ -2,10 +2,10 @@
 
 <div class="nav nav-tabs mt-5 mb-3" id="nav-tab" role="tablist">
   <a class="nav-link active" id="nav-openissues-tab" data-toggle="pill" href="#nav-openissues" role="tab" aria-controls="nav-openissues" aria-selected="true">
-    Open Issues <span class="badge badge-pill badge-danger"><%= @open_issues.count %></span>
+    Open Issues <span class="badge badge-pill badge-danger"><%= @open_issues.size %></span>
   </a>
   <a class="nav-link " id="nav-closedissues-tab" data-toggle="pill" href="#nav-closedissues" role="tab" aria-controls="nav-closedissues" aria-selected="false">
-    Closed Issues <span class="badge badge-pill badge-warning"><%= @closed_issues.count %></span>
+    Closed Issues <span class="badge badge-pill badge-warning"><%= @closed_issues.size %></span>
   </a>
 </div>
 

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -13,7 +13,7 @@
       <% if current_account && current_account.projects.any? %>
         <li class="nav-item nav-link">
           <%= link_to "Manage My Projects", projects_path %>
-          <% count = current_account.notifications.count %>
+          <% count = current_account.notifications.size %>
           <% if count > 0 %>
             <span class="badge badge-pill badge-danger"><%= count %></span>
           <% end %>
@@ -23,7 +23,7 @@
       <% if current_account && current_account.issues.any? %>
         <li class="nav-item nav-link">
           <%= link_to "Manage My Issues", issues_path %>
-          <% count = current_account.notifications.where(issue_id: current_account.issues.map(&:id)).count %>
+          <% count = current_account.notifications.where(issue_id: current_account.issues.map(&:id)).size %>
           <% if count > 0 %>
             <span class="badge badge-pill badge-danger"><%= count %></span>
           <% end %>

--- a/app/views/projects/_issues.html.erb
+++ b/app/views/projects/_issues.html.erb
@@ -12,10 +12,10 @@
     <% issues.each do |issue| %>
       <tr>
         <td>
-          <% count = current_account.notifications.for_issue(issue).count %>
+          <% count = current_account.notifications.for_issue(issue).size %>
           <%= link_to issue.issue_number, project_issue_path(@project, issue) %>
           <% if count > 0 %>
-            <span class="badge badge-pill badge-danger"><%= current_account.notifications.for_issue(issue).count %></span>
+            <span class="badge badge-pill badge-danger"><%= current_account.notifications.for_issue(issue).size %></span>
           <% end %>
         </td>
         <td><%= truncate(issue.description, length: 50) %></td>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -12,7 +12,7 @@
           <div class="card-body">
             <h5 class="card-title">
               <%= link_to project.name, project %>
-              <% count = current_account.notifications.for_project(project).count %>
+              <% count = current_account.notifications.for_project(project).size %>
               <% if count > 0 %>
                 <span class="badge badge-pill badge-danger"><%= count %></span>
               <% end %>
@@ -29,8 +29,8 @@
               </p>
               <p>
                 Issues:
-                <span class="badge badge-pill badge-danger"><%= project.issues.submitted.count %> New</span>
-                <span class="badge badge-pill badge-warning"><%= project.issues.acknowledged.count + project.issues.reopened.count %> In Progress</span>
+                <span class="badge badge-pill badge-danger"><%= project.issues.submitted.size %> New</span>
+                <span class="badge badge-pill badge-warning"><%= project.issues.acknowledged.size + project.issues.reopened.size %> In Progress</span>
               </p>
             </div>
           </div>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -83,16 +83,16 @@
 
 <ul class="nav nav-tabs mt-5 mb-3 responsive" id="nav-tab" role="tablist">
   <li class="nav-item"><a class="nav-link active" id="nav-newissues-tab" data-toggle="pill" href="#nav-newissues" role="tab" aria-controls="nav-newissues" aria-selected="true">
-    New Issues <span class="badge badge-pill badge-danger"><%= @issues.submitted.count %></span>
+    New Issues <span class="badge badge-pill badge-danger"><%= @issues.submitted.size %></span>
   </a></li>
   <li class="nav-item"><a class="nav-link " id="nav-acknowledgedissues-tab" data-toggle="pill" href="#nav-acknowledgedissues" role="tab" aria-controls="nav-acknowledgedissues" aria-selected="false">
-    In Progress <span class="badge badge-pill badge-warning"><%= @issues.acknowledged.count + @issues.reopened.count %></span>
+    In Progress <span class="badge badge-pill badge-warning"><%= @issues.acknowledged.size + @issues.reopened.size %></span>
   </a></li>
   <li class="nav-item"><a class="nav-link " id="nav-resolvedissues-tab" data-toggle="pill" href="#nav-resolvedissues" role="tab" aria-controls="nav-resolvedissues" aria-selected="false">
-    Resolved <span class="badge badge-pill badge-light"><%= @issues.resolved.count %></span>
+    Resolved <span class="badge badge-pill badge-light"><%= @issues.resolved.size %></span>
   </a></li>
   <li class="nav-item"><a class="nav-link " id="nav-dismissedissues-tab" data-toggle="pill" href="#nav-dismissedissues" role="tab" aria-controls="nav-dismissedissues" aria-selected="false">
-    Dismissed <span class="badge badge-pill badge-dark"><%= @issues.dismissed.count %></span>
+    Dismissed <span class="badge badge-pill badge-dark"><%= @issues.dismissed.size %></span>
   </a></li>
   <li class="nav-item"><a class="nav-link" id="nav-settings-tab" data-toggle="pill" href="#nav-settings" role="tab" aria-controls="nav-settings" aria-selected="false">
     Settings

--- a/db/migrate/20190121192516_add_notification_ids_to_account.rb
+++ b/db/migrate/20190121192516_add_notification_ids_to_account.rb
@@ -1,0 +1,6 @@
+class AddNotificationIdsToAccount < ActiveRecord::Migration[5.2]
+  def change
+    add_column :accounts, :notification_encrypted_ids, :string, array: true, default: []
+    remove_column :notifications, :account_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_21_020244) do
+ActiveRecord::Schema.define(version: 2019_01_21_192516) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -60,6 +60,7 @@ ActiveRecord::Schema.define(version: 2019_01_21_020244) do
     t.datetime "locked_at"
     t.string "normalized_email"
     t.string "hashed_email"
+    t.string "notification_encrypted_ids", default: [], array: true
     t.index ["confirmation_token"], name: "index_accounts_on_confirmation_token", unique: true
     t.index ["email"], name: "index_accounts_on_email", unique: true
     t.index ["normalized_email"], name: "index_accounts_on_normalized_email", unique: true
@@ -153,10 +154,8 @@ ActiveRecord::Schema.define(version: 2019_01_21_020244) do
     t.uuid "project_id"
     t.uuid "issue_id"
     t.uuid "issue_comment_id"
-    t.uuid "account_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["account_id"], name: "index_notifications_on_account_id"
     t.index ["issue_comment_id"], name: "index_notifications_on_issue_comment_id"
     t.index ["issue_id"], name: "index_notifications_on_issue_id"
     t.index ["project_id"], name: "index_notifications_on_project_id"
@@ -217,7 +216,6 @@ ActiveRecord::Schema.define(version: 2019_01_21_020244) do
   add_foreign_key "issue_events", "issues"
   add_foreign_key "issue_severity_levels", "projects"
   add_foreign_key "issues", "issue_severity_levels"
-  add_foreign_key "notifications", "accounts"
   add_foreign_key "notifications", "issue_comments"
   add_foreign_key "notifications", "issues"
   add_foreign_key "notifications", "projects"


### PR DESCRIPTION
We welcome contributions involving code, documentation, or design. If you'd like to contribute, please check out [our guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

## Problem
The relation between a notification, account, and issue was leaking sensitive information.

## Solution
Encrypt the notification IDs. 

## Todo
Database migration required.

## Notes for Reviewers
This PR also includes some performance tweaks.

## Checklist
- [ ] Reasonable and adequate test coverage
- [x] Requires a database migration
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`
