### PR TITLE
Add mock project ownership token functionality

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,6 +1,6 @@
 class ProjectsController < ApplicationController
   before_action :authenticate_account!
-  before_action :scope_project, only: [:show, :edit, :delete, :update, :clone_ladder]
+  before_action :scope_project, except: [:index, :new, :create]
   before_action :enforce_existing_project_permissions, except: [:index, :new, :create]
   before_action :enforce_project_creation_permissions, only: [:new, :create]
 
@@ -41,6 +41,14 @@ class ProjectsController < ApplicationController
   def show
   end
 
+  def ownership
+  end
+
+  def confirm_ownership
+    ProjectConfirmationService.confirm!(@project)
+    redirect_to @project
+  end
+
   def update
     if @project.update_attributes(project_params)
       flash[:notice] = 'The project was successfully updated.'
@@ -69,7 +77,7 @@ class ProjectsController < ApplicationController
   end
 
   def scope_project
-    @project = Project.find_by(slug: params[:slug])
+    @project = Project.find_by(slug: params[:slug]) || Project.find_by(slug: params[:project_slug])
     @settings = @project.project_setting
     @issues = @project.issues
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -36,8 +36,8 @@ class Project < ApplicationRecord
     issue_severity_levels.any?
   end
 
-  def verified_settings?
-    project_setting.updated_at != project_setting.created_at
+  def confirmation_token_url
+    url + "beacon.txt"
   end
 
   def moderator?(account)
@@ -60,8 +60,16 @@ class Project < ApplicationRecord
     project_setting.paused?
   end
 
+  def ownership_confirmed?
+    confirmed_at.present?
+  end
+
   def setup_complete?
-    public? && verified_settings? && consequence_ladder?
+    public? && verified_settings? && consequence_ladder? && ownership_confirmed?
+  end
+
+  def verified_settings?
+    project_setting.updated_at != project_setting.created_at
   end
 
   private

--- a/app/services/project_confirmation_service.rb
+++ b/app/services/project_confirmation_service.rb
@@ -11,19 +11,18 @@ class ProjectConfirmationService
   end
 
   def confirm!
-    if confirm_via_oauth || confirm_via_token
-      project.update_attribute(:confirmed_at, DateTime.now)
-    end
+    return false unless confirm_via_oauth || confirm_via_token
+    project.update_attribute(:confirmed_at, DateTime.now)
   end
 
   private
 
-  # TODO Use oauth to link account to GitHub or GitLab account and confirm project ownership
+  # TODO: Use oauth to link account to GitHub or GitLab account and confirm project ownership
   def confirm_via_oauth
     true
   end
 
-  # TODO Visit project's confirmation_token_url to confirm project ownership
+  # TODO: Visit project's confirmation_token_url to confirm project ownership
   def confirm_via_token
     true
   end

--- a/app/services/project_confirmation_service.rb
+++ b/app/services/project_confirmation_service.rb
@@ -1,0 +1,31 @@
+class ProjectConfirmationService
+
+  attr_reader :project
+
+  def self.confirm!(project)
+    new(project: project).confirm!
+  end
+
+  def initialize(project:)
+    @project = project
+  end
+
+  def confirm!
+    if confirm_via_oauth || confirm_via_token
+      project.update_attribute(:confirmed_at, DateTime.now)
+    end
+  end
+
+  private
+
+  # TODO Use oauth to link account to GitHub or GitLab account and confirm project ownership
+  def confirm_via_oauth
+    true
+  end
+
+  # TODO Visit project's confirmation_token_url to confirm project ownership
+  def confirm_via_token
+    true
+  end
+
+end

--- a/app/views/projects/ownership.html.erb
+++ b/app/views/projects/ownership.html.erb
@@ -1,0 +1,24 @@
+<h2><%= @project.name %>: Ownership Confirmation</h2>
+
+<p>To confirm ownership of this project, create a file at the designated URL with the following contents:</p>
+
+<%= form_for @project, url: project_confirm_path(@project) do |f| %>
+
+  <div class="form-group col-sm-6">
+    <%= f.label :token, "Confirmation Token" %>
+    <%= f.text_field :token, value: "BEACON_TOKEN=#{EncryptionService.hash(@project.id)}", disabled: true, class: "form-control" %>
+  </div>
+
+  <div class="form-group col-sm-6">
+    <%= f.label :confirmation_token_url, "Confirmation Token URL" %>
+    <%= f.text_field :confirmation_token_url, disabled: true, class: "form-control" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Verify Ownership", class: "btn btn-primary" %>
+  </div>
+
+<% end %>
+
+<p class="mt-3">Alternately, <a href="#">connect your account</a> to GitHub or GitLab to verify ownership of your repository.</p>
+

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -18,6 +18,18 @@
           <div class="card-text">
             <ul>
               <li>
+                <%= link_to "Ownership Confirmation", project_ownership_path(@project) %>
+                <% if @project.ownership_confirmed? %>
+                  <span class="badge badge-pill badge-success">
+                    √
+                  </span>
+                <% else %>
+                  <span class="badge badge-pill badge-danger">
+                    x
+                  </span>
+                <% end %>
+              </li>
+              <li>
                 <%= link_to "Consequence Ladder", project_issue_severity_levels_path(@project) %>
                 <% if @project.consequence_ladder? %>
                   <span class="badge badge-pill badge-success">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,8 @@ Rails.application.routes.draw do
     resources :issue_severity_levels
     resources :account_project_blocks
     patch "clone_ladder", to: "projects#clone_ladder"
+    get "ownership", to: "projects#ownership"
+    patch "confirm", to: "projects#confirm_ownership"
     resources :reporters, only: [:show]
     resources :respondents, only: [:show]
     resources :issues do

--- a/db/migrate/20190125232410_add_confirmed_at_to_project.rb
+++ b/db/migrate/20190125232410_add_confirmed_at_to_project.rb
@@ -1,0 +1,5 @@
+class AddConfirmedAtToProject < ActiveRecord::Migration[5.2]
+  def change
+    add_column :projects, :confirmed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_21_192516) do
+ActiveRecord::Schema.define(version: 2019_01_25_232410) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -193,6 +193,7 @@ ActiveRecord::Schema.define(version: 2019_01_21_192516) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "has_confirmed_settings", default: false
+    t.datetime "confirmed_at"
     t.index ["account_id"], name: "index_projects_on_account_id"
     t.index ["slug"], name: "index_projects_on_slug", unique: true
   end


### PR DESCRIPTION
We welcome contributions involving code, documentation, or design. If you'd like to contribute, please check out [our guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

## Problem
There is nothing preventing a bad actor from creating a Beacon project for a project that they do not in fact own.

## Solution
Require project confirmation by token or oauth.

## Todo
This is a mock implementation for prototype purposes.

## Notes for Reviewers
Anything that you want to tell the people who are going to review your pull request.

## Checklist
- [ ] Reasonable and adequate test coverage
- [x] Requires a database migration
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`