### PR TITLE
Add links to sign up/sign in with GitHub and GitLab

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -4,6 +4,7 @@
 
   <div class="row">
     <div class="col-sm">
+      <p class="mt-3"><a href="#">Sign up with GitHub</a> | <a href="#">Sign up with GitLab</a></p>
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
         <%= devise_error_messages!.gsub(/^.+\^/,'').html_safe %>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -4,6 +4,7 @@
 
   <div class="row">
     <div class="col-sm">
+      <p class="mt-3"><a href="#">Sign in with GitHub</a> | <a href="#">Sign in with GitLab</a></p>
       <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
         <div class="form-group">
           <%= f.label :email %><br />


### PR DESCRIPTION
We welcome contributions involving code, documentation, or design. If you'd like to contribute, please check out [our guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

## Problem
There is only local account signup and signin

## Solution
Add (mock) links to GitHub and GitLab accounts.

## Todo
Any follow-up tasks that need to happen before or after the PR is merged.

## Notes for Reviewers
Anything that you want to tell the people who are going to review your pull request.

## Checklist
- [ ] Reasonable and adequate test coverage
- [ ] Requires a database migration
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`
