### PR TITLE
Coralineada/respondent template

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -16,6 +16,11 @@
   float: none;
 }
 
+.alert-success {
+  background: $orange;
+  color: $black;
+}
+
 h1 {
   font-size: 2rem;
 }

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -13,7 +13,7 @@ $gray-300: #dee2e6 !default;
 $gray-400: #ced4da !default;
 $gray-500: #adb5bd !default;
 $gray-600: #cbcbcb !default;
-$gray-700: #495057 !default;
+$gray-700: #383E43 !default;
 $gray-800: #073642 !default;
 $gray-900: #002B36 !default;
 $black:    #fff !default;

--- a/app/controllers/issue_comments_controller.rb
+++ b/app/controllers/issue_comments_controller.rb
@@ -61,7 +61,7 @@ class IssueCommentsController < ApplicationController
     if @project.moderator?(current_account) && visible_to_reporter?
       email = @issue.reporter.email
       commenter_kind = "moderator"
-      NotificationService.notify(account: @issue.reporter, project: @project, issue_id: @issue.id, issue_comment_id: @comment.id)
+      NotificationService.notify(account: @issue.reporter, project_id: @project.id, issue_id: @issue.id, issue_comment_id: @comment.id)
     elsif @project.moderator?(current_account) && visible_to_respondent?
       email = @issue.respondent.email
       commenter_kind = "moderator"

--- a/app/controllers/issue_invitations_controller.rb
+++ b/app/controllers/issue_invitations_controller.rb
@@ -4,7 +4,7 @@ class IssueInvitationsController < ApplicationController
   before_action :enforce_permissions
 
   def new
-    @invitation = IssueInvitation.new
+    @invitation = IssueInvitation.new(summary: @project.respondent_template.populate_from(@issue, issue_url(@issue)))
   end
 
   def create

--- a/app/controllers/respondent_templates_controller.rb
+++ b/app/controllers/respondent_templates_controller.rb
@@ -6,12 +6,12 @@ class RespondentTemplatesController < ApplicationController
 
   def new
     @template = RespondentTemplate.new(project_id: @project.id, text: RespondentTemplate.beacon_default.text)
+    projects_with_respondent_template = current_account.projects.select{ |project| project.respondent_template? }
+    @available_templates = (["Beacon Default"] << projects_with_respondent_template.map(&:name)) - [@project.name]
   end
 
   def create
     @template = RespondentTemplate.new(respondent_template_params.merge(project_id: @project.id))
-    projects_with_respondent_template = current_account.projects.select{ |project| project.respondent_template? }
-    @available_templates = (["Beacon Default"] << projects_with_respondent_template.map(&:name)) - [@project.name]
     if @template.save
       redirect_to project_path(@project)
     else

--- a/app/controllers/respondent_templates_controller.rb
+++ b/app/controllers/respondent_templates_controller.rb
@@ -6,8 +6,8 @@ class RespondentTemplatesController < ApplicationController
 
   def new
     @template = RespondentTemplate.new(project_id: @project.id, text: RespondentTemplate.beacon_default.text)
-    projects_with_respondent_template = current_account.projects.select{ |project| project.respondent_template? }
-    @available_templates = (["Beacon Default"] << projects_with_respondent_template.map(&:name)) - [@project.name]
+    projects_with_respondent_template = current_account.projects.select{ |project| project.respondent_template? && project.name != @project.name }
+    @available_templates = (["Beacon Default"] << projects_with_respondent_template.map(&:name)).flatten
   end
 
   def create

--- a/app/controllers/respondent_templates_controller.rb
+++ b/app/controllers/respondent_templates_controller.rb
@@ -1,0 +1,67 @@
+class RespondentTemplatesController < ApplicationController
+
+  before_action :authenticate_account!
+  before_action :scope_project
+  before_action :enforce_permissions
+
+  def new
+    @template = RespondentTemplate.new(project_id: @project.id, text: RespondentTemplate.beacon_default.text)
+  end
+
+  def create
+    @template = RespondentTemplate.new(respondent_template_params.merge(project_id: @project.id))
+    projects_with_respondent_template = current_account.projects.select{ |project| project.respondent_template? }
+    @available_templates = (["Beacon Default"] << projects_with_respondent_template.map(&:name)) - [@project.name]
+    if @template.save
+      redirect_to project_path(@project)
+    else
+      flash[:error] = @template.errors.full_messages
+      render :new
+    end
+  end
+
+  def clone
+    if existing = @project.respondent_template
+      existing.destroy
+    end
+    source = respondent_template_params[:respondent_template_default_source]
+    if source == "Beacon Default"
+      @project.create_respondent_template(text: RespondentTemplate.beacon_default.text)
+    else
+      source = current_account.projects.find_by(name: source)
+      @project.create_respondent_template(text: source.text)
+    end
+    flash[:notice] = "You have successfully updated the respondent template."
+    redirect_to @project
+  end
+
+  def edit
+    @template = @project.respondent_template
+    projects_with_respondent_template = current_account.projects.select{ |project| project.respondent_template? && project.name != @project.name }
+    @available_templates = (["Beacon Default"] << projects_with_respondent_template.map(&:name)).flatten
+  end
+
+  def update
+    @template = @project.respondent_template
+    if @template.update_attributes(respondent_template_params)
+      redirect_to project_path(@project)
+    else
+      flash[:error] = @template.errors.full_messages
+    end
+  end
+
+  private
+
+  def enforce_permissions
+    render_forbidden && return unless current_account.can_manage_respondent_template?(@project)
+  end
+
+  def respondent_template_params
+    params.require(:respondent_template).permit(:text, :respondent_template_default_source)
+  end
+
+  def scope_project
+    @project = Project.find_by(slug: params[:project_slug])
+  end
+
+end

--- a/app/models/concerns/permissions.rb
+++ b/app/models/concerns/permissions.rb
@@ -44,6 +44,10 @@ module Permissions
     project.moderator?(self)
   end
 
+  def can_manage_respondent_template?(project)
+    project.moderator?(self)
+  end
+
   def can_moderate_project?(project)
     project.moderator?(self)
   end

--- a/app/models/respondent_template.rb
+++ b/app/models/respondent_template.rb
@@ -1,0 +1,23 @@
+class RespondentTemplate < ApplicationRecord
+
+  belongs_to :project, optional: true
+
+  validates_presence_of :text
+
+  attr_accessor :respondent_template_default_source
+
+  def self.beacon_default
+    find_by(is_beacon_default: true)
+  end
+
+  def populate_from(issue)
+    text.gsub("[[PROJECT_NAME]]", project.name)
+    text.gsub("[[CODE_OF_CONDUCT_URL]]", project.coc_url)
+    if severity_level = issue.issue_severity_level
+      text.gsub("[[CONSEQUENCE]]", project.issue_severity_levels.find_by(severity: severity_level).consequence)
+    end
+    text.gsub("[[ISSUE_URL]]", issue_url_url(issue))
+    return text
+  end
+
+end

--- a/app/models/respondent_template.rb
+++ b/app/models/respondent_template.rb
@@ -10,13 +10,13 @@ class RespondentTemplate < ApplicationRecord
     find_by(is_beacon_default: true)
   end
 
-  def populate_from(issue)
-    text.gsub("[[PROJECT_NAME]]", project.name)
-    text.gsub("[[CODE_OF_CONDUCT_URL]]", project.coc_url)
+  def populate_from(issue, issue_url)
+    text.gsub!("[[PROJECT_NAME]]", project.name)
+    text.gsub!("[[CODE_OF_CONDUCT_URL]]", project.coc_url)
     if severity_level = issue.issue_severity_level
-      text.gsub("[[CONSEQUENCE]]", project.issue_severity_levels.find_by(severity: severity_level).consequence)
+      text.gsub!("[[CONSEQUENCE]]", severity_level.consequence)
     end
-    text.gsub("[[ISSUE_URL]]", issue_url_url(issue))
+    text.gsub!("[[ISSUE_URL]]", issue_url)
     return text
   end
 

--- a/app/views/issue_invitations/new.html.erb
+++ b/app/views/issue_invitations/new.html.erb
@@ -1,4 +1,4 @@
-<h1><%= link_to @project.name, @project %>: Issue <%= @issue.issue_number %></h1>
+<h1><%= link_to @project.name, @project %>: <%= link_to "Issue #{@issue.issue_number}", project_issue_path(@project, @issue) %></h1>
 
 <h2>Contact Respondent</h2>
 
@@ -10,7 +10,7 @@
 
   <div class="form-group">
     <%= f.label "Issue Summary" %><br />
-    <%= f.text_area :summary, class: "form-control" %>
+    <%= f.text_area :summary, class: "form-control", rows: 20 %>
   </div>
 
   <div class="actions">

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -42,6 +42,19 @@
                 <% end %>
               </li>
               <li>
+                <% if @project.respondent_template? %>
+                  <%= link_to "Respondent Template", project_respondent_template_path(@project, @project.respondent_template) %>
+                  <span class="badge badge-pill badge-success">
+                    √
+                  </span>
+                <% else %>
+                  <%= link_to "Respondent Template", new_project_respondent_template_path(@project) %>
+                  <span class="badge badge-pill badge-danger">
+                    x
+                  </span>
+                <% end %>
+              </li>
+              <li>
                 <%= link_to "Project Settings", project_settings_path(@project)  %>
                 <% if @project.verified_settings? %>
                   <span class="badge badge-pill badge-success">
@@ -75,16 +88,31 @@
         <h2 class="card-title">Links</h2>
         <div class="card-text">
           <ul>
+            <li>
+              <%= link_to "Home Page", @project.url, target: "_new" %>
+            </li>
+            <li>
+              <%= link_to "Code of Conduct", @project.coc_url, target: "_new" %>
+            </li>
+            <% if @project.public? %>
+              <li>
+                <%= link_to "View in Directory", directory_project_path(@project.slug) %>
+              </li>
+            <% end %>
             <% if @project.consequence_ladder? %>
-              <li><%= link_to "Consequence Ladder", project_issue_severity_levels_path(@project) %></li>
+              <li>
+                <%= link_to "Consequence Ladder", project_issue_severity_levels_path(@project) %>
+              </li>
+            <% end %>
+            <% if @project.respondent_template? %>
+              <li>
+                <%= link_to "Respondent Template", edit_project_respondent_template_path(@project, @project.respondent_template) %>
+              </li>
             <% end %>
             <% if @project.account_project_blocks.any? %>
-              <li><%= link_to "Blocked Accounts", project_account_project_blocks_path(@project) %></li>
-            <% end %>
-            <li><%= link_to "Home page", @project.url, target: "_new" %></li>
-            <li><%= link_to "Code of conduct", @project.coc_url, target: "_new" %></li>
-            <% if @project.public? %>
-              <li><%= link_to "View in Directory", directory_project_path(@project.slug) %></li>
+              <li>
+                <%= link_to "Blocked Accounts", project_account_project_blocks_path(@project) %>
+              </li>
             <% end %>
           </ul>
         </div>

--- a/app/views/respondent_templates/edit.html.erb
+++ b/app/views/respondent_templates/edit.html.erb
@@ -1,0 +1,31 @@
+<h1><%= link_to @project.name, @project %>: Respondent Contact Template</h1>
+
+<div class="mb-3" style="border-bottom: 1px solid #ddd">
+  <p>This template will be used when you first contact the respondent of an issue.</p>
+
+  <p>Values like <b>[[VALUE]]</b> will be auto-populated when you use the template to contact a respondent.</p>
+
+  <p>You can customize your respondent template from Beacon defaults or another one of your projects, or create your own.</p>
+
+  <%= form_for @template, url: project_clone_respondent_template_path(@project) do |f| %>
+    <div class="form-group col-sm-6">
+      <%= f.label :clone_from %>
+      <%= f.select :respondent_template_default_source, @available_templates, class: "form-control", include_blank: "Select..." %>
+    </div>
+
+    <div class="actions mb-3">
+      <%= f.submit "Clone", class: "btn btn-primary" %>
+    </div>
+  <% end %>
+
+</div>
+
+<%= form_for @template, url: project_respondent_template_path(@project, @template) do |f| %>
+  <div class="form-group">
+    <%= f.text_area :text, class: "form-control", rows: 20 %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Save", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/app/views/respondent_templates/new.html.erb
+++ b/app/views/respondent_templates/new.html.erb
@@ -1,8 +1,24 @@
 <h1><%= link_to @project.name, @project %>: Respondent Contact Template</h1>
 
-<p>This template will be used when you first contact the respondent of an issue.</p>
+<div class="mb-3" style="border-bottom: 1px solid #ddd">
+  <p>This template will be used when you first contact the respondent of an issue.</p>
 
-<p>Values like <b>[[VALUE]]</b> will be auto-populated when you use the template to contact a respondent.</p>
+  <p>Values like <b>[[VALUE]]</b> will be auto-populated when you use the template to contact a respondent.</p>
+
+  <p>You can customize your respondent template from Beacon defaults or another one of your projects, or create your own.</p>
+
+  <%= form_for @template, url: project_clone_respondent_template_path(@project) do |f| %>
+    <div class="form-group col-sm-6">
+      <%= f.label :clone_from %>
+      <%= f.select :respondent_template_default_source, @available_templates, class: "form-control", include_blank: "Select..." %>
+    </div>
+
+    <div class="actions mb-3">
+      <%= f.submit "Clone", class: "btn btn-primary" %>
+    </div>
+  <% end %>
+
+</div>
 
 <%= form_for @template, url: project_respondent_templates_path(@project) do |f| %>
   <div class="form-group">

--- a/app/views/respondent_templates/new.html.erb
+++ b/app/views/respondent_templates/new.html.erb
@@ -1,0 +1,15 @@
+<h1><%= link_to @project.name, @project %>: Respondent Contact Template</h1>
+
+<p>This template will be used when you first contact the respondent of an issue.</p>
+
+<p>Values like <b>[[VALUE]]</b> will be auto-populated when you use the template to contact a respondent.</p>
+
+<%= form_for @template, url: project_respondent_templates_path(@project) do |f| %>
+  <div class="form-group">
+    <%= f.text_area :text, class: "form-control", rows: 20 %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Save", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,13 +13,7 @@ Rails.application.routes.draw do
   resources :abuse_reports, only: [:new, :create]
   resources :issues
   resources :projects, param: :slug do
-    resources :issue_severity_levels
     resources :account_project_blocks
-    patch "clone_ladder", to: "projects#clone_ladder"
-    get "ownership", to: "projects#ownership"
-    patch "confirm", to: "projects#confirm_ownership"
-    resources :reporters, only: [:show]
-    resources :respondents, only: [:show]
     resources :issues do
       resources :uploads
       resources :issue_comments, only: [:create, :new]
@@ -29,7 +23,15 @@ Rails.application.routes.draw do
       patch "resolve", to: "issues#resolve"
       post "reopen", to: "issues#reopen"
     end
+    resources :issue_severity_levels
+    resources :reporters, only: [:show]
+    resources :respondent_templates, only: [:new, :create, :edit, :update, :show]
+    resources :respondents, only: [:show]
     get "settings", to: "project_settings#edit"
+    get "ownership", to: "projects#ownership"
+    patch "clone_ladder", to: "projects#clone_ladder"
+    patch "clone_respondent_template", to: "respondent_templates#clone"
+    patch "confirm", to: "projects#confirm_ownership"
     patch "settings", to: "project_settings#update"
     post "toggle_pause", to: "project_settings#toggle_pause"
   end

--- a/db/migrate/20190202152603_create_respondent_template.rb
+++ b/db/migrate/20190202152603_create_respondent_template.rb
@@ -1,0 +1,10 @@
+class CreateRespondentTemplate < ActiveRecord::Migration[5.2]
+  def change
+    create_table :respondent_templates, id: :uuid do |t|
+      t.references :project, type: :uuid, foreign_key: true
+      t.text       :text
+      t.boolean    :is_beacon_default, default: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_01_014249) do
+ActiveRecord::Schema.define(version: 2019_02_02_152603) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -227,6 +227,15 @@ ActiveRecord::Schema.define(version: 2019_02_01_014249) do
     t.index ["slug"], name: "index_projects_on_slug", unique: true
   end
 
+  create_table "respondent_templates", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "project_id"
+    t.text "text"
+    t.boolean "is_beacon_default", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["project_id"], name: "index_respondent_templates_on_project_id"
+  end
+
   create_table "suspicious_activity_logs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "controller"
     t.string "action"
@@ -257,5 +266,6 @@ ActiveRecord::Schema.define(version: 2019_02_01_014249) do
   add_foreign_key "project_issues", "projects"
   add_foreign_key "project_settings", "projects"
   add_foreign_key "projects", "accounts"
+  add_foreign_key "respondent_templates", "projects"
   add_foreign_key "suspicious_activity_logs", "accounts"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,3 +29,8 @@ IssueSeverityLevel.create(
   example: "Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior or language,  harassment of an individual, or aggression or disparagement of class of individuals.",
   consequence: "A permanent ban from any sort of interaction in the project community, including pull requests, issues, and comments, for a period specified by moderators."
 )
+
+RespondentTemplate.create(
+  is_beacon_default: true,
+      text: "This is to inform you that you have been named as a respondent on a code of conduct issue on the [[PROJECT_NAME]] project. We are contacting you as part of our investigation of this issue. For reference, you can find our code of conduct at [[CODE_OF_CONDUCT_URL]].\n\nA summary of the issue is provided here:\n\n(Summarize the issue here)\n\nIn the interest of fairness, we would like to give you an opportunity to respond to this issue and provide any context or additional information that may help us in our investigation.\n\nIf we find that you are in fact in violation of our code of conduct, based on our initial assessment of the issue, our enforcement guidelines recommend the following consequence:\n\n\"[[CONSEQUENCE]]\"\n\nTo respond to this issue, please visit [[ISSUE_URL]]. You may be prompted to create an account on Beacon if you don't already have one.\n\nThank you in advance for your prompt attention. As moderators, we promise a fair evaluation of the situation and want to work with you if possible to prevent any further issues in your interactions with our community."
+)

--- a/lib/tasks/defaults.rake
+++ b/lib/tasks/defaults.rake
@@ -1,11 +1,32 @@
 namespace :defaults do
 
   desc 'Create default respondent template'
-  task :respondent_template => :environment do
+  task respondent_template: :environment do
     RespondentTemplate.where(is_beacon_default: true).map(&:destroy)
+    text = %{
+This is to inform you that you have been named as a respondent on a code of conduct issue on the [[PROJECT_NAME]]
+project. We are contacting you as part of our investigation of this issue. For reference, you can find our code
+of conduct at [[CODE_OF_CONDUCT_URL]].
+
+A summary of the issue is provided here:
+
+(Summarize the issue here)
+
+In the interest of fairness, we would like to give you an opportunity to respond to this issue and
+provide any context or additional information that may help us in our investigation.\n\nIf we find that you are
+in fact in violation of our code of conduct, based on our initial assessment of the issue, our enforcement
+guidelines recommend the following consequence:
+
+"[[CONSEQUENCE]]"
+
+To respond to this issue, please visit [[ISSUE_URL]]. You may be prompted to create an account on Beacon if you don't already have one.
+
+Thank you in advance for your prompt attention. As moderators, we promise a fair evaluation of the situation and want
+to work with you if possible to prevent any further issues in your interactions with our community.
+    }
     RespondentTemplate.create(
       is_beacon_default: true,
-      text: "This is to inform you that you have been named as a respondent on a code of conduct issue on the [[PROJECT_NAME]] project. We are contacting you as part of our investigation of this issue. For reference, you can find our code of conduct at [[CODE_OF_CONDUCT_URL]].\n\nA summary of the issue is provided here:\n\n(Summarize the issue here)\n\nIn the interest of fairness, we would like to give you an opportunity to respond to this issue and provide any context or additional information that may help us in our investigation.\n\nIf we find that you are in fact in violation of our code of conduct, based on our initial assessment of the issue, our enforcement guidelines recommend the following consequence:\n\n\"[[CONSEQUENCE]]\"\n\nTo respond to this issue, please visit [[ISSUE_URL]]. You may be prompted to create an account on Beacon if you don't already have one.\n\nThank you in advance for your prompt attention. As moderators, we promise a fair evaluation of the situation and want to work with you if possible to prevent any further issues in your interactions with our community."
+      text: text
     )
   end
 

--- a/lib/tasks/defaults.rake
+++ b/lib/tasks/defaults.rake
@@ -1,0 +1,12 @@
+namespace :defaults do
+
+  desc 'Create default respondent template'
+  task :respondent_template => :environment do
+    RespondentTemplate.where(is_beacon_default: true).map(&:destroy)
+    RespondentTemplate.create(
+      is_beacon_default: true,
+      text: "This is to inform you that you have been named as a respondent on a code of conduct issue on the [[PROJECT_NAME]] project. We are contacting you as part of our investigation of this issue. For reference, you can find our code of conduct at [[CODE_OF_CONDUCT_URL]].\n\nA summary of the issue is provided here:\n\n(Summarize the issue here)\n\nIn the interest of fairness, we would like to give you an opportunity to respond to this issue and provide any context or additional information that may help us in our investigation.\n\nIf we find that you are in fact in violation of our code of conduct, based on our initial assessment of the issue, our enforcement guidelines recommend the following consequence:\n\n\"[[CONSEQUENCE]]\"\n\nTo respond to this issue, please visit [[ISSUE_URL]]. You may be prompted to create an account on Beacon if you don't already have one.\n\nThank you in advance for your prompt attention. As moderators, we promise a fair evaluation of the situation and want to work with you if possible to prevent any further issues in your interactions with our community."
+    )
+  end
+
+end


### PR DESCRIPTION
We welcome contributions involving code, documentation, or design. If you'd like to contribute, please check out [our guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

## Problem
The first contact with a respondent on an issue is important, and moderators need a consistent way to communicate with respondents.

## Solution
Create project respondent templates, and auto-fill the template with relevant issue details when the moderator contacts the respondent.

## Todo
`rake defaults:respondent_template`

## Notes for Reviewers
Anything that you want to tell the people who are going to review your pull request.

## Checklist
- [ ] Reasonable and adequate test coverage
- [ ] Requires a database migration
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`