### PR TITLE
Throttle total number of issues someone can open across projects

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -34,6 +34,10 @@ class Account < ApplicationRecord
     @issues ||= AccountIssue.issues_for_account(id)
   end
 
+  def total_issues_past_24_hours
+    issues.select{ |issue| issue.created_at >= Time.zone.now - 24.hours }.size
+  end
+
   def notifications
     @notifications ||= Notification.notifications_for_account(self)
   end

--- a/app/models/concerns/permissions.rb
+++ b/app/models/concerns/permissions.rb
@@ -60,6 +60,7 @@ module Permissions
     return false unless project.accepting_issues?
     return false if blocked_from_project?(project)
     return false if is_flagged
+    return false if total_issues_past_24_hours >= Setting.throttling(:max_issues_per_day)
     return false if project.issue_count_from_past_24_hours == project.project_setting.rate_per_day
     return true
   end

--- a/app/views/directory/show.html.erb
+++ b/app/views/directory/show.html.erb
@@ -36,7 +36,7 @@
     <% end %>
 
     <h2 class="mt-5">Project Governance</h2>
-    <p><%= @project.name %> is managed by a single individual.</p>
+    <p><%= @project.name %> is managed by a <%= @project.moderators.size == 1 ? "single individual" : "team of moderators" %>.</p>
 
     <% if @project.project_setting.publish_stats? %>
       <h2 class="mt-5">3-Month Activity</h2>

--- a/config/settings/default.yml
+++ b/config/settings/default.yml
@@ -1,3 +1,4 @@
 throttling:
   max_abuse_reports_per_day: <%= ENV.fetch('MAX_ABUSE_REPORTS_PER_DAY', 5) %>
   max_general_contacts_per_day: <%= ENV.fetch('MAX_GENERAL_CONTACTS_PER_DAY', 2) %>
+  max_issues_per_day: <%= ENV.fetch('MAX_ISSUES_PER_DAY', 3) %>


### PR DESCRIPTION
We welcome contributions involving code, documentation, or design. If you'd like to contribute, please check out [our guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

## Problem
A bad actor could open a number of false issues across multiple projects.

## Solution
Throttle the daily total issues that a user can open.

## Todo
The `MAX_ISSUES_PER_DAY` environment variable governs throttling.

## Notes for Reviewers
Anything that you want to tell the people who are going to review your pull request.

## Checklist
- [ ] Reasonable and adequate test coverage
- [ ] Requires a database migration
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`