### PR TITLE
Remove hardcoded email addresses and use env variables

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -4,12 +4,12 @@ class AdminMailer < ApplicationMailer
     @report = params[:report]
     @project = params[:project]
     @reporter = @report.account
-    mail(to: admin_emails, subject: "Beacon: New Abuse Report")
+    mail(to: Setting.emails(:abuse), subject: "Beacon: New Abuse Report")
   end
 
   def notify_on_new_contact_message
     @message = params[:contact_message]
-    mail(to: admin_emails, subject: "Beacon: New Contact Form")
+    mail(to: Setting.emails(:support), subject: "Beacon: New Contact Form")
   end
 
   def notify_on_flag_request
@@ -17,13 +17,7 @@ class AdminMailer < ApplicationMailer
     @account = params[:account]
     @reason = params[:reason]
     @report = params[:report]
-    mail(to: admin_emails, subject: "Beacon: New Account Block Request")
-  end
-
-  private
-
-  def admin_emails
-    Account.admins.pluck(:email)
+    mail(to: Setting.emails(:abuse), subject: "Beacon: New Account Block Request")
   end
 
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'donotreply@coc-beacon.org'
+  default from: Setting.emails(:robot)
   layout 'mailer'
 end

--- a/config/settings/default.yml
+++ b/config/settings/default.yml
@@ -2,3 +2,7 @@ throttling:
   max_abuse_reports_per_day: <%= ENV.fetch('MAX_ABUSE_REPORTS_PER_DAY', 5) %>
   max_general_contacts_per_day: <%= ENV.fetch('MAX_GENERAL_CONTACTS_PER_DAY', 2) %>
   max_issues_per_day: <%= ENV.fetch('MAX_ISSUES_PER_DAY', 3) %>
+emails:
+  robot: <%= ENV.fetch('ROBOT_EMAIL_ADDRESS', "donotreply@coc-beacon.net") %>
+  support: <%= ENV.fetch('SUPPORT_EMAIL_ADDRESS', "support@coc-beacon.net") %>
+  abuse: <%= ENV.fetch('ABUSE_EMAIL_ADDRESS', "abuse@coc-beacon.net") %>


### PR DESCRIPTION
We welcome contributions involving code, documentation, or design. If you'd like to contribute, please check out [our guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

## Problem
Non-admin email 'from' email addresses were hardcoded.

## Solution
Move them to environment variables with sensible defaults.

## Todo
Any follow-up tasks that need to happen before or after the PR is merged.

## Notes for Reviewers
Anything that you want to tell the people who are going to review your pull request.

## Checklist
- [ ] Reasonable and adequate test coverage
- [ ] Requires a database migration
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`
