### PR TITLE
Optionally display moderator names on directory projects

### DIFF
--- a/app/controllers/accounts/registrations_controller.rb
+++ b/app/controllers/accounts/registrations_controller.rb
@@ -2,9 +2,6 @@ module Accounts
   class RegistrationsController < Devise::RegistrationsController
     prepend_before_action :check_captcha, only: [:create]
 
-    # before_action :configure_sign_up_params, only: [:create]
-    # before_action :configure_account_update_params, only: [:update]
-
     # GET /resource/sign_up
     # def new
     #   super
@@ -72,4 +69,5 @@ module Accounts
       respond_with resource
     end
   end
+
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,7 @@
 class ApplicationController < ActionController::Base
 
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
   if Rails.env.production?
     http_basic_authenticate_with name: ENV['HTTP_AUTH_USER'], password: ENV['HTTP_AUTH_PASSWORD']
   end
@@ -13,6 +15,13 @@ class ApplicationController < ActionController::Base
       account_id: current_account ? current_account.id : nil
     )
     render(status: :forbidden, plain: "Oh no you don't.")
+  end
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name])
   end
 
 end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -24,7 +24,8 @@ class InvitationsController < ApplicationController
       invitation = Invitation.new(
         invitation_params.merge(
           account_id: current_account.id,
-          organization_id: organization.id
+          organization_id: organization.id,
+          is_default_moderator: true
         )
       )
     else

--- a/app/controllers/project_settings_controller.rb
+++ b/app/controllers/project_settings_controller.rb
@@ -34,6 +34,7 @@ class ProjectSettingsController < ApplicationController
     params.require(:project_setting).permit(
       :rate_per_day,
       :require_3rd_party_auth,
+      :show_moderator_names,
       :minimum_3rd_party_auth_age_in_days,
       :allow_anonymous_issues,
       :publish_stats,

--- a/app/views/account_project_blocks/index.html.erb
+++ b/app/views/account_project_blocks/index.html.erb
@@ -12,7 +12,7 @@
               <% if @project.project_setting.allow_anonymous_issues && @project.issues.map(&:reporter).include?( block.account) %>
                 Anonymous Reporter
               <% else %>
-                <%= block.account.email %>
+                <%= block.account.display_name %>
               <% end %>
             </h2>
             <div class="card-text">

--- a/app/views/admin/accounts/index.html.erb
+++ b/app/views/admin/accounts/index.html.erb
@@ -5,6 +5,7 @@
 <table class="table" id="accounts" data-sorting="true">
   <thead>
     <tr>
+      <th>Name</th>
       <th>Email</th>
       <th>Created At</th>
       <th>Updated At</th>
@@ -15,6 +16,7 @@
   <tbody>
     <% @accounts.each do |account| %>
       <tr>
+        <td><%= account.name %></td>
         <td><%= link_to account.email, admin_account_path(account) %></td>
         <td><%= account.created_at.strftime("%D") %></td>
         <td><%= account.updated_at.strftime("%D") %></td>

--- a/app/views/admin/accounts/show.html.erb
+++ b/app/views/admin/accounts/show.html.erb
@@ -1,6 +1,6 @@
 <% title "Admin: #{@account.email}" %>
 
-<h1><%= @account.email %></h1>
+<h1><%= @account.email %> (<%= @account.display_name %>)</h1>
 
 <div class="actions mt-1">
   <% if current_account.can_lock_account? %>

--- a/app/views/admin/projects/index.html.erb
+++ b/app/views/admin/projects/index.html.erb
@@ -22,7 +22,7 @@
         <td>
           <ul>
             <% project.moderators.each do |moderator| %>
-              <li><%= moderator.email %></li>
+              <li><%= moderator.display_name %></li>
             <% end %>
           </ul>
         </td>

--- a/app/views/admin_mailer/notify_on_abuse_report.html.inky
+++ b/app/views/admin_mailer/notify_on_abuse_report.html.inky
@@ -5,7 +5,7 @@
 <container style="margin-top: 2em;">
   <row>
     <columns>
-      <p>Submitted by <%= @reporter.email %>.</p>
+      <p>Submitted by <%= @reporter.display_name %>.</p>
       <blockquote><%= @report.description %></blockquote>
     </columns>
   </row>

--- a/app/views/admin_mailer/notify_on_abuse_report.txt.erb
+++ b/app/views/admin_mailer/notify_on_abuse_report.txt.erb
@@ -1,6 +1,6 @@
 New abuse report on <%= @project.name %>
 
-An abuse report was made by <%= @reporter.email %>:
+An abuse report was made by <%= @reporter.display_name %>:
 
 <%= @report.description %>
 

--- a/app/views/admin_mailer/notify_on_flag_request.txt.erb
+++ b/app/views/admin_mailer/notify_on_flag_request.txt.erb
@@ -1,6 +1,6 @@
 New account flag request
 
-An abuse report was made on <%= @account.email %> by <%= @reporter.email %>:
+An abuse report was made on <%= @account.display_name %> by <%= @reporter.email %>:
 
 Reason:
 <%= @reason %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -6,6 +6,11 @@
   <%= devise_error_messages! %>
 
   <div class="form-group">
+    <%= f.label :name %><br />
+    <%= f.text_field :name, autofocus: true, class: "form-control" %>
+  </div>
+
+  <div class="form-group">
     <%= f.label :email %><br />
     <%= f.email_field :email, disabled: true, autocomplete: "email", class: "form-control" %>
   </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -11,8 +11,13 @@
         <%= devise_error_messages!.gsub(/^.+\^/,'').html_safe %>
 
         <div class="form-group">
+          <%= f.label :name %><br />
+          <%= f.text_field :name, autofocus: true, class: "form-control" %>
+        </div>
+
+        <div class="form-group">
           <%= f.label :email %><br />
-          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>
+          <%= f.email_field :email, autocomplete: "email", class: "form-control" %>
         </div>
 
         <div class="form-group">

--- a/app/views/directory/show.html.erb
+++ b/app/views/directory/show.html.erb
@@ -31,6 +31,13 @@
     <h2>Project Governance</h2>
     <p><%= @project.name %> is managed by a <%= @project.moderators.size == 1 ? "single individual" : "team of moderators" %>.</p>
 
+    <% if @project.project_setting.show_moderator_names? %>
+      <ul>
+        <% @project.moderators.each do |moderator| %>
+          <li><%= moderator.display_name %></li>
+        <% end %>
+      </ul>
+    <% end %>
     <h2 class="mt-4">Issue Guidelines</h2>
     <p>This project has the following requirements for opening an issue:</p>
     <ul>

--- a/app/views/issues/_comment.html.erb
+++ b/app/views/issues/_comment.html.erb
@@ -2,7 +2,7 @@
 <div class="card mb-3 ml-3 mr-3 <%= card_bg %>" style="width: 90%">
   <div class="card-body">
     <h2 class="card-title">
-      <%= comment.commenter == comment.issue.reporter && project.obscure_reporter_email? ? "Reporter" : comment.commenter.email %>
+      <%= comment.commenter == comment.issue.reporter && project.obscure_reporter_email? ? "Reporter" : comment.commenter.display_name %>
     </h2>
     <div class="card-text">
       <p><%= comment.text %></p>

--- a/app/views/issues/_moderator_view.html.erb
+++ b/app/views/issues/_moderator_view.html.erb
@@ -15,7 +15,7 @@
         <% if @project.obscure_reporter_email? %>
           Anonymous
         <% else %>
-          <%= @issue.reporter.email %><br />
+          <%= @issue.reporter.display_name %><br />
         <% end %>
         <% if @reporter_block %>
           <p>
@@ -34,7 +34,7 @@
     <% if @issue.respondent %>
       <ul>
         <li>
-          <%= @issue.respondent.email %><br />
+          <%= @issue.respondent.display_name %><br />
           <%= link_to "Details", project_respondent_path(@project, @issue.respondent.id), class: "btn btn-sm btn-warning" %>
           <% if @respondent_block %>
             <p>
@@ -259,12 +259,12 @@
           <% if project.project_setting.allow_anonymous_issues? %>
             by anonymous
           <% else %>
-            by <%= issue.reporter.email %>
+            by <%= issue.reporter.display_name %>
           <% end %>
           (<%= issue.created_at.in_time_zone.strftime("%a %b %d %Y at %l:%M %p %Z") %>)
         </li>
         <% issue.issue_events.each do |event| %>
-          <li><%= event.event %> by <%= event.actor.email %> (<%= event.updated_at.in_time_zone.strftime("%a %b %d %Y at %l:%M %p %Z") %>)
+          <li><%= event.event %> by <%= event.actor.display_name %> (<%= event.updated_at.in_time_zone.strftime("%a %b %d %Y at %l:%M %p %Z") %>)
         <% end %>
       </ul>
 

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -65,7 +65,7 @@
     </ul>
     <div>
       <% if current_account %>
-        <%= link_to current_account.email, edit_account_registration_path(current_account) %>
+        <%= link_to current_account.display_name, edit_account_registration_path(current_account) %>
         <%= link_to "Sign Out", destroy_account_session_path, method: :delete, class: "btn btn-primary" %>
       <% else %>
         <%= link_to "Sign In", new_account_session_path, class: "btn btn-primary" %>

--- a/app/views/organizations/moderators.html.erb
+++ b/app/views/organizations/moderators.html.erb
@@ -6,7 +6,7 @@
     <ul>
       <% @moderators.each do |moderator| %>
         <li>
-          <%= moderator.email %>
+          <%= moderator.display_name %>
           <% if @organization.owner?(moderator) %>
             (Owner)
           <% end %>

--- a/app/views/project_settings/edit.html.erb
+++ b/app/views/project_settings/edit.html.erb
@@ -15,6 +15,11 @@
   </div>
 
   <div class="form-group col-sm-6">
+    <%= f.label :show_moderator_names, "Show Moderator Names or Emails in Directory" %>
+    <%= f.check_box :show_moderator_names, class: "toggle", :data => { :toggle => 'toggle' } %>
+  </div>
+
+  <div class="form-group col-sm-6">
     <%= f.label :allow_anonymous_issues, "Hide Reporter Identity" %>
     <%= f.check_box :allow_anonymous_issues, class: "toggle", :data => { :toggle => 'toggle' } %>
   </div>

--- a/app/views/projects/moderators.html.erb
+++ b/app/views/projects/moderators.html.erb
@@ -6,7 +6,7 @@
     <ul>
       <% @moderators.each do |moderator| %>
         <li>
-          <%= moderator.email %>
+          <%= moderator.display_name %>
           <% if @project.owner?(moderator) %>
             (Owner)
           <% end %>

--- a/db/migrate/20190225012143_add_show_moderators_to_project_settings.rb
+++ b/db/migrate/20190225012143_add_show_moderators_to_project_settings.rb
@@ -1,0 +1,5 @@
+class AddShowModeratorsToProjectSettings < ActiveRecord::Migration[5.2]
+  def change
+    add_column :project_settings, :show_moderator_names, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_24_191504) do
+ActiveRecord::Schema.define(version: 2019_02_25_012143) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -219,6 +219,9 @@ ActiveRecord::Schema.define(version: 2019_02_24_191504) do
     t.string "slug"
     t.text "description"
     t.uuid "account_id"
+    t.datetime "flagged_at"
+    t.text "flagged_reason"
+    t.datetime "confirmed_at"
     t.index ["account_id"], name: "index_organizations_on_account_id"
   end
 
@@ -240,6 +243,7 @@ ActiveRecord::Schema.define(version: 2019_02_24_191504) do
     t.uuid "project_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "show_moderator_names", default: false
     t.index ["project_id"], name: "index_project_settings_on_project_id"
   end
 


### PR DESCRIPTION
We welcome contributions involving code, documentation, or design. If you'd like to contribute, please check out [our guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

## Problem
Some project owners may wish to display moderator names publicly.

## Solution
Accept names as part of account creation and update, add a checkbox to project settings for displaying names.

## Todo
Any follow-up tasks that need to happen before or after the PR is merged.

## Notes for Reviewers
Anything that you want to tell the people who are going to review your pull request.

## Checklist
- [ ] Reasonable and adequate test coverage
- [x] Requires a database migration
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`
