### PR TITLE
mini_racer and DATABASE_HOST setup fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem "turbolinks", "~> 5"
 gem "twilio-ruby"
 gem "uglifier", ">= 1.3.0"
 gem "valid_email2"
+gem "mini_racer"
 
 group :development, :test do
   gem "brakeman"

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem "google-cloud-storage", require: false
 gem 'inky-rb', require: 'inky'
 gem "jbuilder", "~> 2.5"
 gem "jquery-rails"
+gem "mini_racer"
 gem "normailize"
 gem "omniauth-github", github: "intridea/omniauth-github"
 gem "omniauth-gitlab", github: "linchus/omniauth-gitlab"
@@ -38,7 +39,6 @@ gem "turbolinks", "~> 5"
 gem "twilio-ruby"
 gem "uglifier", ">= 1.3.0"
 gem "valid_email2"
-gem "mini_racer"
 
 group :development, :test do
   gem "brakeman"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,6 +196,7 @@ GEM
     jwt (2.1.0)
     launchy (2.4.3)
       addressable (~> 2.3)
+    libv8 (6.7.288.46.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -215,6 +216,8 @@ GEM
     mimemagic (0.3.3)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
+    mini_racer (0.2.4)
+      libv8 (>= 6.3)
     minitest (5.11.3)
     msgpack (1.2.4)
     multi_json (1.13.1)
@@ -452,6 +455,7 @@ DEPENDENCIES
   jquery-rails
   launchy
   listen (>= 3.0.5, < 3.2)
+  mini_racer
   normailize
   omniauth-github!
   omniauth-gitlab!
@@ -485,4 +489,4 @@ RUBY VERSION
    ruby 2.5.3p105
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/config/database.yml
+++ b/config/database.yml
@@ -7,7 +7,7 @@
 default: &default
   adapter: postgresql
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  host: <%= ENV.fetch("DATABASE_URL") { '127.0.0.1' } %>
+  host: <%= ENV.fetch("DATABASE_HOST") { '127.0.0.1' } %>
   username: <%= ENV['DATABASE_USERNAME'] %>
   password: <%= ENV['DATABASE_PASSWORD'] %>
   timeout: 5000


### PR DESCRIPTION
## Problem

Couldn't get the setup to work properly.

## Solutions

- Adds `mini_racer` which bundles v8 to prevent errors when compiling assets
- User the `DATABASE_HOST` as specified in the documentation and fits with the `host` option of the postgresql adapter (`DATABASE_URL` could be a better solution but needs to use the `url:` option of the adapter)
- ~~credentials were tied to an unkown `RAILS_MASTER_KEY`, so it's tied to the one in `config/master.key` with a random `secret_key_base` generated with `rails secret` (could be just a simple string too)~~

## Notes for Reviewers

`DATABASE_URL` may be used in production, ~~`config/credentials.yml.enc` and `config/master.key` should probably not be tracked in git~~

## Checklist

- [ ] Reasonable and adequate test coverage -> "Works on my computer", hoping it works on CI
- [ ] Requires a database migration -> No
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb` -> No need
- [ ] Any new environment variables are documented and added to `.env.development.example` -> No new one added
