### PR TITLE
Add make db-seed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ After adding the migration, you can either run
 
 ### Adding seed data
 
-`make dev` then `rake db:seed`
+`make db-seed` OR `make dev` then `rake db:seed`
 
 ### Running the specs
 

--- a/makefile
+++ b/makefile
@@ -7,6 +7,7 @@ usage:
 	@echo "  * build        - Build images"
 	@echo "  * update-deps  - Install missing runtime dependencies"
 	@echo "  * db-migrate   - Runs the migrations"
+	@echo "  * db-seed      - Seed the database"
 	@echo "  * dev          - Connects to the server"
 	@echo "  * run          - Runs the server"
 	@echo "  * tear-down    - Removes all the containers and tears down the setup"
@@ -23,6 +24,8 @@ db-create:
 	$(call dc-run, bundle exec rake db:create)
 db-migrate:
 	$(call dc-run, bundle exec rake db:migrate)
+db-seed:
+	$(call dc-run, bundle exec rake db:seed)
 dev:
 	$(call dc-run, ash)
 console:


### PR DESCRIPTION
## Problem

Seeding the database requires loading Docker's dev environment and run `rake db:seed`.

This is a small quality-of-life improvement, nothing really important.

## Solution

Add a new `make db-seed` similar to the `make db-migrate` and others.

## Notes for Reviewers

It's not important.

## Checklist

- [ ] Reasonable and adequate test coverage
- [ ] Requires a database migration
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`