### PR TITLE
Rake task to rotate encryption keys

### DIFF
--- a/app/services/encryption_service.rb
+++ b/app/services/encryption_service.rb
@@ -5,7 +5,7 @@ class EncryptionService
     Digest::MD5.hexdigest(text)
   end
 
-  def self.encrypt(text, secret_key_base=nil)
+  def self.encrypt(text, secret_key_base = nil)
     secret_key_base ||= Setting.encryption(:secret_key_base)
     len   = ActiveSupport::MessageEncryptor.key_len
     salt  = SecureRandom.hex len
@@ -15,7 +15,7 @@ class EncryptionService
     "#{salt}$$#{encrypted_data}"
   end
 
-  def self.decrypt(text, secret_key_base=nil)
+  def self.decrypt(text, secret_key_base = nil)
     secret_key_base ||= Setting.encryption(:secret_key_base)
     salt, data = text.split('$$')
     len   = ActiveSupport::MessageEncryptor.key_len

--- a/app/services/encryption_service.rb
+++ b/app/services/encryption_service.rb
@@ -5,20 +5,25 @@ class EncryptionService
     Digest::MD5.hexdigest(text)
   end
 
-  def self.encrypt(text)
+  def self.encrypt(text, secret_key_base=nil)
+    secret_key_base ||= Setting.encryption(:secret_key_base)
     len   = ActiveSupport::MessageEncryptor.key_len
     salt  = SecureRandom.hex len
-    key   = ActiveSupport::KeyGenerator.new(Setting.encryption(:secret_key_base)).generate_key(salt, len)
+    key   = ActiveSupport::KeyGenerator.new(secret_key_base).generate_key(salt, len)
     crypt = ActiveSupport::MessageEncryptor.new key
     encrypted_data = crypt.encrypt_and_sign(text)
     "#{salt}$$#{encrypted_data}"
   end
 
-  def self.decrypt(text)
+  def self.decrypt(text, secret_key_base=nil)
+    secret_key_base ||= Setting.encryption(:secret_key_base)
     salt, data = text.split('$$')
     len   = ActiveSupport::MessageEncryptor.key_len
-    key   = ActiveSupport::KeyGenerator.new(Setting.encryption(:secret_key_base)).generate_key(salt, len)
+    key   = ActiveSupport::KeyGenerator.new(secret_key_base).generate_key(salt, len)
     crypt = ActiveSupport::MessageEncryptor.new(key)
     crypt.decrypt_and_verify(data)
+  rescue StandardError => e
+    Rails.logger.info("Failed to decrypt: #{e.backtrace}\n#{e}")
+    return nil
   end
 end

--- a/lib/tasks/rotate_keys.rake
+++ b/lib/tasks/rotate_keys.rake
@@ -1,0 +1,85 @@
+namespace :rotate_keys do
+
+  task :help do
+    %w{account account_issue issue_comment issue_event issue issue_invitation project_issue}.each do |t|
+      puts "rake rotate_keys:#{t}"
+    end
+  end
+
+  task :account, [:old_key, :new_key] => :environment do |task, args|
+    old_key = args[:old_key]
+    new_key = args[:new_key]
+    Account.all.each do |i|
+      if i.phone_encrypted.present?
+        phone = EncryptionService.decrypt(i.phone_encrypted, old_key)
+        i.update_attribute(:phone_encrypted, EncryptionService.encrypt(phone, new_key))
+      end
+    end
+  end
+
+  task :account_issue, [:old_key, :new_key] => :environment do |task, args|
+    old_key = args[:old_key]
+    new_key = args[:new_key]
+    AccountIssue.all.each do |i|
+      id = EncryptionService.decrypt(i.issue_encrypted_id, old_key)
+      i.update_attribute(:issue_encrypted_id, EncryptionService.encrypt(id, new_key))
+    end
+  end
+
+  task :issue_comment, [:old_key, :new_key] => :environment do |task, args|
+    old_key = args[:old_key]
+    new_key = args[:new_key]
+    IssueComment.all.each do |i|
+      id = EncryptionService.decrypt(i.commenter_encrypted_id, old_key)
+      i.update_attribute(:commenter_encrypted_id, EncryptionService.encrypt(ceid, new_key))
+    end
+  end
+
+  task :issue_event, [:old_key, :new_key] => :environment do |task, args|
+    old_key = args[:old_key]
+    new_key = args[:new_key]
+    IssueEvent.all.each do |i|
+      id = EncryptionService.decrypt(i.actor_encrypted_id, old_key)
+      i.update_attribute(:actor_encrypted_id, EncryptionService.encrypt(id, new_key))
+    end
+  end
+
+  task :issue, [:old_key, :new_key] => :environment do |task, args|
+    old_key = args[:old_key]
+    new_key = args[:new_key]
+    Issue.all.each do |i|
+      project_id = EncryptionService.decrypt(i.project_encrypted_id, old_key)
+      reporter_id = EncryptionService.decrypt(i.reporter_encrypted_id, old_key)
+      respondent_id = EncryptionService.decrypt(i.respondent_encrypted_id, old_key) if i.respondent_encrypted_id
+      respondent_id ||= nil
+      i.update_attributes(
+        project_encrypted_id: EncryptionService.encrypt(project_id, new_key),
+        reporter_encrypted_id: EncryptionService.encrypt(reporter_id, new_key),
+        respondent_encrypted_id: respondent_id && EncryptionService.encrypt(respondent_id, new_key) || nil
+      )
+    end
+  end
+
+  task :issue_invitation, [:old_key, :new_key] => :environment do |task, args|
+    old_key = args[:old_key]
+    new_key = args[:new_key]
+    IssueInvitation.all.each do |i|
+      id_1 = EncryptionService.decrypt(i.respondent_encrypted_id, old_key)
+      id_2 = EncryptionService.decrypt(i.issue_encrypted_id, old_key)
+      i.update_attributes(
+        respondent_encrypted_id: EncryptionService.encrypt(id_1, new_key),
+        issue_encrypted_id: EncryptionService.encrypt(id_2, new_key)
+      )
+    end
+  end
+
+  task :project_issue, [:old_key, :new_key] => :environment do |task, args|
+    old_key = args[:old_key]
+    new_key = args[:new_key]
+    ProjectIssue.all.each do |i|
+      id = EncryptionService.decrypt(i.issue_encrypted_id, old_key)
+      i.update_attribute(:issue_encrypted_id, EncryptionService.encrypt(id, new_key))
+    end
+  end
+
+end


### PR DESCRIPTION
We welcome contributions involving code, documentation, or design. If you'd like to contribute, please check out [our guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

## Problem
Encryption keys will need to be rotated regularly.

## Solution
Add rake tasks for decrypting and reencrypting all secret relations and other secret fields.

## Todo
Any follow-up tasks that need to happen before or after the PR is merged.

## Notes for Reviewers
Anything that you want to tell the people who are going to review your pull request.

## Checklist
- [ ] Reasonable and adequate test coverage
- [ ] Requires a database migration
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`
