### PR TITLE
Make key rotation rake tasks idempotent

### DIFF
--- a/app/services/encryption_service.rb
+++ b/app/services/encryption_service.rb
@@ -22,8 +22,5 @@ class EncryptionService
     key   = ActiveSupport::KeyGenerator.new(secret_key_base).generate_key(salt, len)
     crypt = ActiveSupport::MessageEncryptor.new(key)
     crypt.decrypt_and_verify(data)
-  rescue StandardError => e
-    Rails.logger.info("Failed to decrypt: #{e.backtrace}\n#{e}")
-    return nil
   end
 end

--- a/lib/tasks/rotate_keys.rake
+++ b/lib/tasks/rotate_keys.rake
@@ -36,8 +36,8 @@ namespace :rotate_keys do
       begin
         id = EncryptionService.decrypt(i.issue_encrypted_id, old_key)
         i.update_attribute(:issue_encrypted_id, EncryptionService.encrypt(id, new_key))
-      rescue ActiveSupport::MessageEncryptor::InvalidMessage
-        puts "Unable to decrypt for account_issue #{i.id}"
+      rescue ActiveSupport::MessageEncryptor::InvalidMessage => e
+        puts "Unable to decrypt for account_issue #{i.id}: #{e}"
       end
     end
   end
@@ -49,8 +49,8 @@ namespace :rotate_keys do
       begin
         id = EncryptionService.decrypt(i.commenter_encrypted_id, old_key)
         i.update_attribute(:commenter_encrypted_id, EncryptionService.encrypt(ceid, new_key))
-      rescue ActiveSupport::MessageEncryptor::InvalidMessage
-        puts "Unable to decrypt for issue_comment #{i.id}"
+      rescue ActiveSupport::MessageEncryptor::InvalidMessage => e
+        puts "Unable to decrypt for issue_comment #{i.id}: #{e}"
       end
     end
   end
@@ -62,8 +62,8 @@ namespace :rotate_keys do
       begin
         id = EncryptionService.decrypt(i.actor_encrypted_id, old_key)
         i.update_attribute(:actor_encrypted_id, EncryptionService.encrypt(id, new_key))
-      rescue ActiveSupport::MessageEncryptor::InvalidMessage
-        puts "Unable to decrypt for issue_event #{i.id}"
+      rescue ActiveSupport::MessageEncryptor::InvalidMessage => e
+        puts "Unable to decrypt for issue_event #{i.id}: #{e}: #{e}"
       end
     end
   end
@@ -76,14 +76,14 @@ namespace :rotate_keys do
         project_id = EncryptionService.decrypt(i.project_encrypted_id, old_key)
         reporter_id = EncryptionService.decrypt(i.reporter_encrypted_id, old_key)
         respondent_id = EncryptionService.decrypt(i.respondent_encrypted_id, old_key) if i.respondent_encrypted_id
-        respondent_id ||= nil
+        respondent_id ||= ni: #{e}l
         i.update_attributes(
           project_encrypted_id: EncryptionService.encrypt(project_id, new_key),
           reporter_encrypted_id: EncryptionService.encrypt(reporter_id, new_key),
           respondent_encrypted_id: respondent_id && EncryptionService.encrypt(respondent_id, new_key) || nil
         )
-      rescue ActiveSupport::MessageEncryptor::InvalidMessage
-        puts "Unable to decrypt for account_issue #{i.id}"
+      rescue ActiveSupport::MessageEncryptor::InvalidMessage => e
+        puts "Unable to decrypt for account_issue #{i.id}: #{e}"
       end
     end
   end
@@ -96,11 +96,11 @@ namespace :rotate_keys do
         id_1 = EncryptionService.decrypt(i.respondent_encrypted_id, old_key)
         id_2 = EncryptionService.decrypt(i.issue_encrypted_id, old_key)
         i.update_attributes(
-          respondent_encrypted_id: EncryptionService.encrypt(id_1, new_key),
+          respondent_encrypted_id: EncryptionService.encrypt(i: #{e}d_1, new_key),
           issue_encrypted_id: EncryptionService.encrypt(id_2, new_key)
         )
-      rescue ActiveSupport::MessageEncryptor::InvalidMessage
-        puts "Unable to decrypt for issue_invitation #{i.id}"
+      rescue ActiveSupport::MessageEncryptor::InvalidMessage => e
+        puts "Unable to decrypt for issue_invitation #{i.id}: #{e}"
       end
     end
   end
@@ -112,8 +112,8 @@ namespace :rotate_keys do
       begin
         id = EncryptionService.decrypt(i.issue_encrypted_id, old_key)
         i.update_attribute(:issue_encrypted_id, EncryptionService.encrypt(id, new_key))
-      rescue ActiveSupport::MessageEncryptor::InvalidMessage
-        puts "Unable to decrypt for project_issue #{i.id}"
+      rescue ActiveSupport::MessageEncryptor::InvalidMessage => e
+        puts "Unable to decrypt for project_issue #{i.id}: #{e}"
       end
     end
   end

--- a/lib/tasks/rotate_keys.rake
+++ b/lib/tasks/rotate_keys.rake
@@ -11,8 +11,20 @@ namespace :rotate_keys do
     new_key = args[:new_key]
     Account.all.each do |i|
       if i.phone_encrypted.present?
-        phone = EncryptionService.decrypt(i.phone_encrypted, old_key)
-        i.update_attribute(:phone_encrypted, EncryptionService.encrypt(phone, new_key))
+        begin
+          phone = EncryptionService.decrypt(i.phone_encrypted, old_key)
+          i.update_attribute(:phone_encrypted, EncryptionService.encrypt(phone, new_key))
+        rescue ActiveSupport::MessageEncryptor::InvalidMessage => e
+          puts "Unable to decrypt phone number for account #{i.id}: #{e}"
+        end
+      end
+      begin
+        decrypted_notification_ids = i.notification_encrypted_ids.map{ |n| EncryptionService.decrypt(n, old_key) }
+        next unless decrypted_notification_ids.any?
+        reencrypted_notification_ids = decrypted_notification_ids.map{ |n| EncryptionService.encrypt(n, new_key) }
+        i.update_attribute(:notification_encrypted_ids, reencrypted_notification_ids)
+      rescue ActiveSupport::MessageEncryptor::InvalidMessage => e
+        puts "Unable to decrypt notification IDs for account #{i.id}: #{e}"
       end
     end
   end
@@ -21,8 +33,12 @@ namespace :rotate_keys do
     old_key = args[:old_key]
     new_key = args[:new_key]
     AccountIssue.all.each do |i|
-      id = EncryptionService.decrypt(i.issue_encrypted_id, old_key)
-      i.update_attribute(:issue_encrypted_id, EncryptionService.encrypt(id, new_key))
+      begin
+        id = EncryptionService.decrypt(i.issue_encrypted_id, old_key)
+        i.update_attribute(:issue_encrypted_id, EncryptionService.encrypt(id, new_key))
+      rescue ActiveSupport::MessageEncryptor::InvalidMessage
+        puts "Unable to decrypt for account_issue #{i.id}"
+      end
     end
   end
 
@@ -30,8 +46,12 @@ namespace :rotate_keys do
     old_key = args[:old_key]
     new_key = args[:new_key]
     IssueComment.all.each do |i|
-      id = EncryptionService.decrypt(i.commenter_encrypted_id, old_key)
-      i.update_attribute(:commenter_encrypted_id, EncryptionService.encrypt(ceid, new_key))
+      begin
+        id = EncryptionService.decrypt(i.commenter_encrypted_id, old_key)
+        i.update_attribute(:commenter_encrypted_id, EncryptionService.encrypt(ceid, new_key))
+      rescue ActiveSupport::MessageEncryptor::InvalidMessage
+        puts "Unable to decrypt for issue_comment #{i.id}"
+      end
     end
   end
 
@@ -39,8 +59,12 @@ namespace :rotate_keys do
     old_key = args[:old_key]
     new_key = args[:new_key]
     IssueEvent.all.each do |i|
-      id = EncryptionService.decrypt(i.actor_encrypted_id, old_key)
-      i.update_attribute(:actor_encrypted_id, EncryptionService.encrypt(id, new_key))
+      begin
+        id = EncryptionService.decrypt(i.actor_encrypted_id, old_key)
+        i.update_attribute(:actor_encrypted_id, EncryptionService.encrypt(id, new_key))
+      rescue ActiveSupport::MessageEncryptor::InvalidMessage
+        puts "Unable to decrypt for issue_event #{i.id}"
+      end
     end
   end
 
@@ -48,15 +72,19 @@ namespace :rotate_keys do
     old_key = args[:old_key]
     new_key = args[:new_key]
     Issue.all.each do |i|
-      project_id = EncryptionService.decrypt(i.project_encrypted_id, old_key)
-      reporter_id = EncryptionService.decrypt(i.reporter_encrypted_id, old_key)
-      respondent_id = EncryptionService.decrypt(i.respondent_encrypted_id, old_key) if i.respondent_encrypted_id
-      respondent_id ||= nil
-      i.update_attributes(
-        project_encrypted_id: EncryptionService.encrypt(project_id, new_key),
-        reporter_encrypted_id: EncryptionService.encrypt(reporter_id, new_key),
-        respondent_encrypted_id: respondent_id && EncryptionService.encrypt(respondent_id, new_key) || nil
-      )
+      begin
+        project_id = EncryptionService.decrypt(i.project_encrypted_id, old_key)
+        reporter_id = EncryptionService.decrypt(i.reporter_encrypted_id, old_key)
+        respondent_id = EncryptionService.decrypt(i.respondent_encrypted_id, old_key) if i.respondent_encrypted_id
+        respondent_id ||= nil
+        i.update_attributes(
+          project_encrypted_id: EncryptionService.encrypt(project_id, new_key),
+          reporter_encrypted_id: EncryptionService.encrypt(reporter_id, new_key),
+          respondent_encrypted_id: respondent_id && EncryptionService.encrypt(respondent_id, new_key) || nil
+        )
+      rescue ActiveSupport::MessageEncryptor::InvalidMessage
+        puts "Unable to decrypt for account_issue #{i.id}"
+      end
     end
   end
 
@@ -64,12 +92,16 @@ namespace :rotate_keys do
     old_key = args[:old_key]
     new_key = args[:new_key]
     IssueInvitation.all.each do |i|
-      id_1 = EncryptionService.decrypt(i.respondent_encrypted_id, old_key)
-      id_2 = EncryptionService.decrypt(i.issue_encrypted_id, old_key)
-      i.update_attributes(
-        respondent_encrypted_id: EncryptionService.encrypt(id_1, new_key),
-        issue_encrypted_id: EncryptionService.encrypt(id_2, new_key)
-      )
+      begin
+        id_1 = EncryptionService.decrypt(i.respondent_encrypted_id, old_key)
+        id_2 = EncryptionService.decrypt(i.issue_encrypted_id, old_key)
+        i.update_attributes(
+          respondent_encrypted_id: EncryptionService.encrypt(id_1, new_key),
+          issue_encrypted_id: EncryptionService.encrypt(id_2, new_key)
+        )
+      rescue ActiveSupport::MessageEncryptor::InvalidMessage
+        puts "Unable to decrypt for issue_invitation #{i.id}"
+      end
     end
   end
 
@@ -77,8 +109,12 @@ namespace :rotate_keys do
     old_key = args[:old_key]
     new_key = args[:new_key]
     ProjectIssue.all.each do |i|
-      id = EncryptionService.decrypt(i.issue_encrypted_id, old_key)
-      i.update_attribute(:issue_encrypted_id, EncryptionService.encrypt(id, new_key))
+      begin
+        id = EncryptionService.decrypt(i.issue_encrypted_id, old_key)
+        i.update_attribute(:issue_encrypted_id, EncryptionService.encrypt(id, new_key))
+      rescue ActiveSupport::MessageEncryptor::InvalidMessage
+        puts "Unable to decrypt for project_issue #{i.id}"
+      end
     end
   end
 

--- a/lib/tasks/rotate_keys.rake
+++ b/lib/tasks/rotate_keys.rake
@@ -63,7 +63,7 @@ namespace :rotate_keys do
         id = EncryptionService.decrypt(i.actor_encrypted_id, old_key)
         i.update_attribute(:actor_encrypted_id, EncryptionService.encrypt(id, new_key))
       rescue ActiveSupport::MessageEncryptor::InvalidMessage => e
-        puts "Unable to decrypt for issue_event #{i.id}: #{e}: #{e}"
+        puts "Unable to decrypt for issue_event #{i.id}: #{e}"
       end
     end
   end
@@ -76,7 +76,7 @@ namespace :rotate_keys do
         project_id = EncryptionService.decrypt(i.project_encrypted_id, old_key)
         reporter_id = EncryptionService.decrypt(i.reporter_encrypted_id, old_key)
         respondent_id = EncryptionService.decrypt(i.respondent_encrypted_id, old_key) if i.respondent_encrypted_id
-        respondent_id ||= ni: #{e}l
+        respondent_id ||= nil
         i.update_attributes(
           project_encrypted_id: EncryptionService.encrypt(project_id, new_key),
           reporter_encrypted_id: EncryptionService.encrypt(reporter_id, new_key),
@@ -96,7 +96,7 @@ namespace :rotate_keys do
         id_1 = EncryptionService.decrypt(i.respondent_encrypted_id, old_key)
         id_2 = EncryptionService.decrypt(i.issue_encrypted_id, old_key)
         i.update_attributes(
-          respondent_encrypted_id: EncryptionService.encrypt(i: #{e}d_1, new_key),
+          respondent_encrypted_id: EncryptionService.encrypt(id_1, new_key),
           issue_encrypted_id: EncryptionService.encrypt(id_2, new_key)
         )
       rescue ActiveSupport::MessageEncryptor::InvalidMessage => e


### PR DESCRIPTION
We welcome contributions involving code, documentation, or design. If you'd like to contribute, please check out [our guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

Please refer to our [contributing guidelines](https://github.com/ContributorCovenant/beacon/blob/release/CONTRIBUTING.md) and follow the guidance in that document to improve the chances of your PR being merged.

## Problem
With key rotation, any failure could leave a record in an indeterminate state.

## Solution
Make encryption key rotation idempotent.

## Todo
Any follow-up tasks that need to happen before or after the PR is merged.

## Notes for Reviewers
Anything that you want to tell the people who are going to review your pull request.

## Checklist
- [ ] Reasonable and adequate test coverage
- [ ] Requires a database migration
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`
