### PR TITLE
Stub email validation in specs

### DIFF
--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 92.59
+    "covered_percent": 92.54
   }
 }

--- a/spec/controllers/issue_comments_controller_spec.rb
+++ b/spec/controllers/issue_comments_controller_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe IssueCommentsController, type: :controller do
     let(:issue)       { FactoryBot.create(:issue, project_id: project.id, reporter_id: reporter.id) }
 
     before do
+      allow_any_instance_of(ValidEmail2::Address).to receive(:valid_mx?) { true }
       allow(Project).to receive(:find_by).and_return(project)
       allow(Issue).to receive(:find).and_return(issue)
       allow(issue).to receive(:project).and_return(project)

--- a/spec/controllers/issue_invitations_controller_spec.rb
+++ b/spec/controllers/issue_invitations_controller_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe IssueInvitationsController, type: :controller do
     let(:issue)       { Issue.new(id: SecureRandom.uuid, issue_number: 1) }
 
     before do
+      allow_any_instance_of(ValidEmail2::Address).to receive(:valid_mx?) { true }
       allow(Project).to receive(:find_by).and_return(project)
       allow(Issue).to receive(:find).and_return(issue)
       allow(issue).to receive(:project).and_return(project)

--- a/spec/controllers/issues_controller_spec.rb
+++ b/spec/controllers/issues_controller_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe IssuesController, type: :controller do
     let!(:project)    { FactoryBot.create(:project, account: moderator) }
 
     before do
+      allow_any_instance_of(ValidEmail2::Address).to receive(:valid_mx?) { true }
       allow_any_instance_of(Issue).to receive(:set_issue_number)
       Role.create(account_id: moderator.id, project_id: project.id, is_owner: true)
     end

--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe OrganizationsController, type: :controller do
-
-end

--- a/spec/features/bad_actor_spec.rb
+++ b/spec/features/bad_actor_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 describe "the registration process", type: :feature do
 
   before do
+    allow_any_instance_of(ValidEmail2::Address).to receive(:valid_mx?) { true }
     allow_any_instance_of(Accounts::RegistrationsController).to receive(:verify_recaptcha).and_return(true)
   end
 

--- a/spec/features/moderator_spec.rb
+++ b/spec/features/moderator_spec.rb
@@ -17,6 +17,7 @@ describe "moderation", type: :feature do
   end
 
   before do
+    allow_any_instance_of(ValidEmail2::Address).to receive(:valid_mx?) { true }
     Role.create(account_id: moderator.id, project_id: project.id, is_owner: true)
     login_as(moderator, scope: :account)
   end

--- a/spec/features/organization_spec.rb
+++ b/spec/features/organization_spec.rb
@@ -4,6 +4,10 @@ describe "organization management", type: :feature do
 
   let(:maintainer) { FactoryBot.create(:danielle) }
 
+  before do
+    allow_any_instance_of(ValidEmail2::Address).to receive(:valid_mx?) { true }
+  end
+
   it "lets a user create an organization" do
     login_as(maintainer, scope: :account)
     visit root_path

--- a/spec/features/project_spec.rb
+++ b/spec/features/project_spec.rb
@@ -6,6 +6,7 @@ describe "The project setup process", type: :feature do
   let!(:project)      { FactoryBot.create(:project, account: maintainer, public: true) }
 
   before do
+    allow_any_instance_of(ValidEmail2::Address).to receive(:valid_mx?) { true }
     Role.create(account_id: maintainer.id, project_id: project.id, is_owner: true)
   end
 

--- a/spec/features/reporter_spec.rb
+++ b/spec/features/reporter_spec.rb
@@ -7,6 +7,7 @@ describe "the reporting process", type: :feature do
   let(:reporter) { FactoryBot.create(:ricky) }
 
   before do
+    allow_any_instance_of(ValidEmail2::Address).to receive(:valid_mx?) { true }
     allow_any_instance_of(Project).to receive(:show_in_directory?).and_return(true)
     allow_any_instance_of(Accounts::RegistrationsController).to receive(:verify_recaptcha).and_return(true)
     allow_any_instance_of(IssuesController).to receive(:verify_recaptcha).and_return(true)

--- a/spec/features/respondent_spec.rb
+++ b/spec/features/respondent_spec.rb
@@ -9,6 +9,7 @@ describe "the respondent experience", type: :feature do
   let!(:issue)      { FactoryBot.create(:issue, reporter_id: reporter.id, project_id: project.id) }
 
   before do
+    allow_any_instance_of(ValidEmail2::Address).to receive(:valid_mx?) { true }
     AccountIssue.create(issue_id: issue.id, account: respondent)
     allow_any_instance_of(Issue).to receive(:respondent).and_return(respondent)
   end

--- a/spec/models/concerns/permissions_spec.rb
+++ b/spec/models/concerns/permissions_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Permissions do
   let(:private_project) { FactoryBot.create(:project, account: kate) }
 
   before do
+    allow_any_instance_of(ValidEmail2::Address).to receive(:valid_mx?) { true }
     allow(public_project).to receive(:public?).and_return(true)
     allow(private_project).to receive(:public?).and_return(false)
     allow(paused_project).to receive(:paused?).and_return(true)

--- a/spec/services/notification_service_spec.rb
+++ b/spec/services/notification_service_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe NotificationService do
   let(:issue_2)   { FactoryBot.create(:issue, project_id: project.id) }
   let(:issue_3)   { FactoryBot.create(:issue, project_id: project.id) }
 
+  before do
+    allow_any_instance_of(ValidEmail2::Address).to receive(:valid_mx?) { true }
+  end
+
   describe "#notify" do
 
     it "creates a notification" do


### PR DESCRIPTION
We welcome contributions involving code, documentation, or design. If you'd like to contribute, please check out [our guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

Please refer to our [contributing guidelines](https://github.com/ContributorCovenant/beacon/blob/release/CONTRIBUTING.md) and follow the guidance in that document to improve the chances of your PR being merged.

## Problem
Accounts created in specs were performing email validation, which made the specs take too long.

## Solution
Stub email validation in all specs.

## Todo
Any follow-up tasks that need to happen before or after the PR is merged.

## Notes for Reviewers
Anything that you want to tell the people who are going to review your pull request.

## Checklist
- [ ] Reasonable and adequate test coverage
- [ ] Requires a database migration
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`
