### PR TITLE
Enable autofill for 2fa code

### DIFF
--- a/app/views/devise/devise_authy/verify_authy.html.erb
+++ b/app/views/devise/devise_authy/verify_authy.html.erb
@@ -6,21 +6,29 @@
     <div class="col-sm">
       <%= verify_authy_form do %>
         <div class="form-group">
-          <%= label_tag 'authy-token' %>
-          <%= text_field_tag :token, "", :autocomplete => :off, :id => 'authy-token' %>
+          <%= label_tag '2fa code' %><br />
+          <%= text_field_tag :token, "", :autocomplete => "one-time-code", id: 'authy-token' %>
         </div>
         <div class="form-group">
           <%= check_box_tag :remember_device %>
-          <span><%= I18n.t('remember_device', {:scope => 'devise'}) %></span>
+          <span><%= I18n.t('remember_device', {scope: 'devise'}) %></span>
         </div>
         <div class="actions">
-          <%= authy_request_sms_link %>
-          <%= submit_tag I18n.t('submit_token', {:scope => 'devise'}), :class => 'btn btn-primary' %>
+          <a id="authy-request-sms-link" data-remote="true" rel="nofollow" data-method="post" href="/accounts/request-sms" class="btn btn-primary">Send SMS</a>
+          <%= submit_tag I18n.t('submit_token', {scope: 'devise'}), :class => 'btn btn-primary' %>
         </div>
       <% end %>
     </div>
   </div>
 </div>
+
+<%= javascript_tag do %>
+  $(function () {
+    var token;
+    token=document.getElementById("authy-token");
+    token.setAttribute("autocomplete","one-time-code");
+  });
+<% end %>
 
 <% if @onetouch_uuid %>
     <script>

--- a/app/views/devise/devise_authy/verify_authy_installation.html.erb
+++ b/app/views/devise/devise_authy/verify_authy_installation.html.erb
@@ -6,14 +6,22 @@
     <div class="col-sm">
       <%= verify_authy_installation_form do %>
         <div class="form-group">
-          <%= label_tag :token %>
-          <%= text_field_tag :token, "", autocomplete: :off, id: 'authy-token', class: "form-control" %>
-          <%= authy_request_sms_link %>
+          <%= label_tag :token, "2fa Token:" %>
+          <%= text_field_tag :token, "", autocomplete: "one-time-code", id: "authy-token", class: "form-control" %>
         </div>
         <div class="actions">
+          <a id="authy-request-sms-link" data-remote="true" rel="nofollow" data-method="post" href="/accounts/request-sms" class="btn btn-primary">Send Code</a>
           <%= submit_tag I18n.t('enable_my_account', {:scope => 'devise'}), :class => 'btn btn-primary' %>
         </div>
       <% end %>
     </div>
   </div>
 </div>
+
+<%= javascript_tag do %>
+  $(function () {
+    var token;
+    token=document.getElementById("authy-token");
+    token.setAttribute("autocomplete","one-time-code");
+  });
+<% end %>

--- a/config/locales/devise.authy.en.yml
+++ b/config/locales/devise.authy.en.yml
@@ -1,6 +1,6 @@
 en:
   devise:
-    submit_token: 'Check Token'
+    submit_token: 'Confirm Token'
     submit_token_title: 'Please enter your 2fa token:'
     authy_register_title: 'Enable Two factor authentication'
     enable_authy: 'Enable'


### PR DESCRIPTION
We welcome contributions involving code, documentation, or design. If you'd like to contribute, please check out [our guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

Please refer to our [contributing guidelines](https://github.com/ContributorCovenant/beacon/blob/release/CONTRIBUTING.md) and follow the guidance in that document to improve the chances of your PR being merged.

## Problem
Authy, the 2fa gem, disables autofill on SMS tokens, preventing autofill by Mac OS and iOS.

## Solution
Override the autocomplete field setting.

## Todo
Any follow-up tasks that need to happen before or after the PR is merged.

## Notes for Reviewers
Anything that you want to tell the people who are going to review your pull request.

## Checklist
- [ ] Reasonable and adequate test coverage
- [ ] Requires a database migration
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`
