### PR TITLE
Bulk import org projects from GitHub

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -30,3 +30,7 @@ Style/RescueStandardError:
 # URISchemes: http, https
 Metrics/LineLength:
   Max: 154
+
+Style/GuardClause:
+  Exclude:
+    - 'app/controllers/projects_controller.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'inky-rb', require: 'inky'
 gem "jbuilder", "~> 2.5"
 gem "jquery-rails"
 gem "normailize"
+gem "octokit"
 gem "omniauth-github", github: "intridea/omniauth-github"
 gem "omniauth-gitlab", github: "linchus/omniauth-gitlab"
 gem "pg"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,6 +231,8 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
+    octokit (4.13.0)
+      sawyer (~> 0.8.0, >= 0.5.3)
     omniauth (1.9.0)
       hashie (>= 3.4.6, < 3.7.0)
       rack (>= 1.6.2, < 3)
@@ -355,6 +357,9 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    sawyer (0.8.1)
+      addressable (>= 2.3.5, < 2.6)
+      faraday (~> 0.8, < 1.0)
     selenium-webdriver (3.141.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2, >= 1.2.2)
@@ -453,6 +458,7 @@ DEPENDENCIES
   launchy
   listen (>= 3.0.5, < 3.2)
   normailize
+  octokit
   omniauth-github!
   omniauth-gitlab!
   pg

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -40,6 +40,16 @@ class OrganizationsController < ApplicationController
     render :show
   end
 
+  def import_projects_from_github
+    results = GithubImportService.new(current_account, @organization).import_projects
+    if results[:success]
+      flash[:info] = "Successfully imported #{results[:count]} project(s)."
+    else
+      flash[:error] = "Could not import projects: #{results[:error]}."
+    end
+    redirect_to organization_path(@organization)
+  end
+
   def clone_ladder
     source = ladder_params[:consequence_ladder_default_source]
     if source == "Beacon Default"
@@ -74,7 +84,8 @@ class OrganizationsController < ApplicationController
       :name,
       :url,
       :coc_url,
-      :description
+      :description,
+      :remote_org_name
     )
   end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -58,6 +58,9 @@ class ProjectsController < ApplicationController
   end
 
   def show
+    unless @project.coc_url.present?
+      flash[:error] = "This project does not have a code of conduct URL. To set it, click 'Edit' below."
+    end
   end
 
   def ownership

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -7,14 +7,14 @@ class Project < ApplicationRecord
   belongs_to :account
   belongs_to :organization, optional: true
   has_one :project_setting, dependent: :destroy
-  has_one :respondent_template
-  has_many :abuse_report_subjects
-  has_many :account_project_blocks
-  has_many :invitations
-  has_many :issue_severity_levels
-  has_many :notifications
-  has_many :project_issues
-  has_many :roles
+  has_one :respondent_template, dependent: :destroy
+  has_many :abuse_report_subjects, dependent: :destroy
+  has_many :account_project_blocks, dependent: :destroy
+  has_many :invitations, dependent: :destroy
+  has_many :issue_severity_levels, dependent: :destroy
+  has_many :notifications, dependent: :destroy
+  has_many :project_issues, dependent: :destroy
+  has_many :roles, dependent: :destroy
   has_many :moderators, through: :roles, source: :account
 
   before_create :set_slug
@@ -95,6 +95,7 @@ class Project < ApplicationRecord
     complete ||= false unless consequence_ladder?
     complete ||= false unless ownership_confirmed?
     complete ||= false unless respondent_template?
+    complete ||= false unless coc_url.present?
     complete = complete.nil? ? true : false
     update_attribute(:setup_complete, complete) unless setup_complete == complete
     return complete

--- a/app/services/github_import_service.rb
+++ b/app/services/github_import_service.rb
@@ -37,9 +37,9 @@ class GithubImportService
       project.project_setting.touch
       project.check_setup_complete?
     end
-    results = { success: true, count: organization.projects.count - starting_count }
+    return { success: true, count: organization.projects.count - starting_count }
   rescue StandardError => e
-    results = { success: false, error: e }
+    return { success: false, error: e }
   end
 
   private
@@ -57,7 +57,8 @@ class GithubImportService
 
   def verify_membership
     true
-    #members.include?(account.credentials)
+    # TODO: wire up to account credentials and verify that the current account is in the org member list
+    # members.include?(account.credentials)
   end
 
 end

--- a/app/services/github_import_service.rb
+++ b/app/services/github_import_service.rb
@@ -1,0 +1,63 @@
+require 'octokit'
+
+class GithubImportService
+
+  attr_reader :account, :organization
+
+  def initialize(account, organization)
+    @account = account
+    @organization = organization
+  end
+
+  def import_projects
+    raise "you are not a member of this GitHub organization" unless verify_membership
+
+    starting_count = organization.projects.count
+
+    repositories.each do |repository|
+      next if Project.find_by(name: [repository.name, repository.name.titleize])
+      coc_url = organization.coc_url.present? && organization.coc_url || repository.code_of_conduct&.html_url || ""
+      project = Project.create!(
+        name: repository.name.titleize,
+        url: repository.html_url,
+        description: repository.description || "",
+        account_id: organization.account_id,
+        coc_url: coc_url,
+        organization_id: organization.id,
+        confirmed_at: DateTime.now,
+        public: true
+      )
+      IssueSeverityLevel.clone_from_org_template_for_project(project) if organization.issue_severity_levels.any?
+      if respondent_template = organization.respondent_template
+        RespondentTemplate.create(
+          project_id: project.id,
+          text: respondent_template.text
+        )
+      end
+      project.project_setting.touch
+      project.check_setup_complete?
+    end
+    results = { success: true, count: organization.projects.count - starting_count }
+  rescue StandardError => e
+    results = { success: false, error: e }
+  end
+
+  private
+
+  def client
+    @client ||= Octokit::Client.new
+  end
+
+  def repositories
+    client.organization_repositories(
+      organization.remote_org_name,
+      accept: "application/vnd.github.scarlet-witch-preview+json"
+    )
+  end
+
+  def verify_membership
+    true
+    #members.include?(account.credentials)
+  end
+
+end

--- a/app/views/organizations/edit.html.erb
+++ b/app/views/organizations/edit.html.erb
@@ -23,8 +23,13 @@
     <%= f.text_area :description, class: "form-control" %>
   </div>
 
+  <div class="form-group col-sm-6">
+    <label for="organization_remote_org_name">GitHub/GitLab Organization Name</label><br />
+    <%= f.text_field :remote_org_name, class: "form-control" %>
+  </div>
+
   <div class="actions">
     <%= f.submit "Update Organization", class: "btn btn-primary" %>
-    <%= button_to "Cancel", @organization, class: "btn btn-warning" %>
+    <%= link_to "Cancel", @organization, class: "btn btn-warning" %>
   </div>
 <% end %>

--- a/app/views/organizations/new.html.erb
+++ b/app/views/organizations/new.html.erb
@@ -26,6 +26,11 @@ settings for managing your organization after it is created.</p>
     <%= f.text_area :description, class: "form-control" %>
   </div>
 
+  <div class="form-group col-sm-6">
+    <label for="organization_remote_org_name">GitHub/GitLab Organization Name</label><br />
+    <%= f.text_field :remote_org_name, class: "form-control" %>
+  </div>
+
   <div class="actions">
     <%= f.submit "Create Organization", class: "btn btn-primary" %>
   </div>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -64,9 +64,12 @@
 
 <h1 class="float-left mt-5 mr-3">Projects</h1>
 
-<div class="actions ml-3 mt-5 mb-3">
-  <%= link_to "New Project", new_project_path(organization_id: @organization.id), class: "btn btn-primary" %>
-</div>
+<% if current_account.can_manage_organization?(@organization) %>
+  <div class="actions ml-3 mt-5 mb-3">
+    <%= link_to "New Project", new_project_path(organization_id: @organization.id), class: "btn btn-primary" %>
+    <%= link_to "Import Projects from GitHub", organization_import_projects_from_github_path(@organization), class: "btn btn-primary" %>
+  </div>
+<% end %>
 
 <div class="container">
   <div class="row">

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -4,7 +4,7 @@
   <div class="col">
     <h1>
       <% if @project.organization %>
-        <%= @project.organization.name %>:
+        <%= link_to @project.organization.name, @project.organization %>:
       <% end %>
       <%= @project.name %>
     </h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
     resources :issue_severity_levels
     resources :respondent_templates, only: [:new, :create, :edit, :update, :show]
     get "moderators", to: "organizations#moderators"
+    get "import_projects_from_github", to: "organizations#import_projects_from_github"
     post "remove_moderator", to: "organizations#remove_moderator"
     patch "clone_ladder", to: "organizations#clone_ladder"
     post "clone_respondent_template", to: "respondent_templates#clone"

--- a/db/migrate/20190311231942_add_remote_org_name_to_organizations.rb
+++ b/db/migrate/20190311231942_add_remote_org_name_to_organizations.rb
@@ -1,0 +1,5 @@
+class AddRemoteOrgNameToOrganizations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :organizations, :remote_org_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_10_200320) do
+ActiveRecord::Schema.define(version: 2019_03_11_231942) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -233,6 +233,11 @@ ActiveRecord::Schema.define(version: 2019_03_10_200320) do
     t.string "slug"
     t.text "description"
     t.uuid "account_id"
+    t.datetime "flagged_at"
+    t.text "flagged_reason"
+    t.datetime "confirmed_at"
+    t.string "confirmation_token_url"
+    t.string "remote_org_name"
     t.index ["account_id"], name: "index_organizations_on_account_id"
   end
 


### PR DESCRIPTION
## Problem
Organizations with broad project portfolios on GitHub shouldn't have to add projects one-by-one.

## Solution
Allow bulk import of public projects from GitHub.

## Todo
Wire up account credentials to import service after #88 is merged.

## Notes for Reviewers
Anything that you want to tell the people who are going to review your pull request.

## Checklist
- [ ] Reasonable and adequate test coverage
- [x] Requires a database migration
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`