### PR TITLE
Bulk import org projects from GitLab

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "devise"
 gem 'devise-authy'
 gem "dotenv-rails"
 gem "fittings"
+gem "gitlab"
 gem "google-cloud-storage", require: false
 gem 'inky-rb', require: 'inky'
 gem "jbuilder", "~> 2.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,6 +149,9 @@ GEM
     ffi (1.9.25)
     fittings (0.2.2)
     foundation_emails (2.2.1.0)
+    gitlab (4.10.0)
+      httparty (~> 0.14, >= 0.14.0)
+      terminal-table (~> 1.5, >= 1.5.1)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     google-api-client (0.27.3)
@@ -177,6 +180,9 @@ GEM
       signet (~> 0.7)
     hashie (3.6.0)
     htmlentities (4.3.4)
+    httparty (0.16.3)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
     httpclient (2.8.3)
     i18n (1.4.0)
       concurrent-ruby (~> 1.0)
@@ -399,6 +405,8 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    terminal-table (1.8.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
@@ -451,6 +459,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   fittings
+  gitlab
   google-cloud-storage
   inky-rb
   jbuilder (~> 2.5)

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -50,6 +50,16 @@ class OrganizationsController < ApplicationController
     redirect_to organization_path(@organization)
   end
 
+  def import_projects_from_gitlab
+    results = GitlabImportService.new(current_account, @organization).import_projects
+    if results[:success]
+      flash[:info] = "Successfully imported #{results[:count]} project(s)."
+    else
+      flash[:error] = "Could not import projects: #{results[:error]}."
+    end
+    redirect_to organization_path(@organization)
+  end
+
   def clone_ladder
     source = ladder_params[:consequence_ladder_default_source]
     if source == "Beacon Default"

--- a/app/services/gitlab_import_service.rb
+++ b/app/services/gitlab_import_service.rb
@@ -1,0 +1,65 @@
+require 'gitlab'
+
+class GitlabImportService
+
+  attr_reader :account, :organization
+
+  def initialize(account, organization)
+    @account = account
+    @organization = organization
+  end
+
+  def import_projects
+    starting_count = organization.projects.count
+
+    repositories.each do |repository|
+      next unless repository_is_in_org?(repository)
+      next if Project.find_by(name: [repository.name, repository.name.titleize])
+
+      project = Project.create!(
+        name: repository.name.titleize,
+        url: repository.web_url,
+        description: "",
+        account_id: organization.account_id,
+        coc_url: organization.coc_url || "",
+        organization_id: organization.id,
+        confirmed_at: DateTime.now,
+        public: true
+      )
+
+      IssueSeverityLevel.clone_from_org_template_for_project(project) if organization.issue_severity_levels.any?
+
+      if respondent_template = organization.respondent_template
+        RespondentTemplate.create(
+          project_id: project.id,
+          text: respondent_template.text
+        )
+      end
+
+      project.project_setting.touch
+      project.check_setup_complete?
+    end
+    return { success: true, count: organization.projects.count - starting_count }
+  rescue StandardError => e
+    return { success: false, error: e }
+  end
+
+  private
+
+  def client
+    @client ||= Gitlab.client(
+      endpoint: "https://gitlab.com/api/v4/",
+      # TODO when oauth PR is merged, grab the oauth token and use it here
+      private_token: account.credentials.gitlab.token
+    )
+  end
+
+  def repositories
+    client.projects(membership: true)
+  end
+
+  def repository_is_in_org?(repository)
+    repository.namespace.full_path == organization.remote_org_name
+  end
+
+end

--- a/app/services/gitlab_import_service.rb
+++ b/app/services/gitlab_import_service.rb
@@ -49,7 +49,7 @@ class GitlabImportService
   def client
     @client ||= Gitlab.client(
       endpoint: "https://gitlab.com/api/v4/",
-      # TODO when oauth PR is merged, grab the oauth token and use it here
+      # TODO: when oauth PR is merged, grab the oauth token and use it here
       private_token: account.credentials.gitlab.token
     )
   end

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -68,6 +68,7 @@
   <div class="actions ml-3 mt-5 mb-3">
     <%= link_to "New Project", new_project_path(organization_id: @organization.id), class: "btn btn-primary" %>
     <%= link_to "Import Projects from GitHub", organization_import_projects_from_github_path(@organization), class: "btn btn-primary" %>
+    <%= link_to "Import Projects from GitLab", organization_import_projects_from_gitlab_path(@organization), class: "btn btn-primary" %>
   </div>
 <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
     resources :respondent_templates, only: [:new, :create, :edit, :update, :show]
     get "moderators", to: "organizations#moderators"
     get "import_projects_from_github", to: "organizations#import_projects_from_github"
+    get "import_projects_from_gitlab", to: "organizations#import_projects_from_gitlab"
     post "remove_moderator", to: "organizations#remove_moderator"
     patch "clone_ladder", to: "organizations#clone_ladder"
     post "clone_respondent_template", to: "respondent_templates#clone"


### PR DESCRIPTION
## Problem
Organizations with broad project portfolios on GitLab shouldn't have to add projects one-by-one.

## Solution
Allow bulk import of public projects from GitLab.

## Todo
Wire up account credentials to import service after #88 is merged.

## Notes for Reviewers
Anything that you want to tell the people who are going to review your pull request.

## Checklist
- [ ] Reasonable and adequate test coverage
- [ ] Requires a database migration
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`