### PR TITLE
Use Database host for the host name from the environment

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -7,7 +7,7 @@
 default: &default
   adapter: postgresql
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  host: <%= ENV.fetch("DATABASE_URL") { '127.0.0.1' } %>
+  host: <%= ENV.fetch("DATABASE_HOST") { '127.0.0.1' } %>
   username: <%= ENV['DATABASE_USERNAME'] %>
   password: <%= ENV['DATABASE_PASSWORD'] %>
   timeout: 5000


### PR DESCRIPTION
## Problem
When using the dockerized environment, it was trying to connect to the localhost database instead of the dockerized db because the the env variable referenced had a different name in the `.env.development.sample` 

## Solution
Change the database yml to use the correct environment variable

