### PR TITLE
Only send SMS on new issue creation

### DIFF
--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -137,6 +137,7 @@ class IssuesController < ApplicationController
       project: @project,
       issue: @issue
     ).notify_of_new_issue.deliver_now
+    NotificationService.notify_moderators_on_issue_via_sms(@project, @issue)
   end
 
   def notify_on_status_change

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -8,8 +8,6 @@ class NotificationService
     )
     account.notification_encrypted_ids << EncryptionService.encrypt(notification.id)
     account.save
-    # Notify on new issue creation
-    notify_via_sms(account, project, issue_id) if issue_comment_id.nil?
   end
 
   def self.notified!(account:, issue_id:)


### PR DESCRIPTION
## Problem
SMS messages were being sent with every notification.

## Solution
Only send an SMS if a new issue is created.

Fixes #150 