### PR TITLE
Moderator can open an issue and invite reporter

### DIFF
--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -45,6 +45,7 @@ class IssuesController < ApplicationController
   end
 
   def show
+    @invitation = IssueInvitation.new
     @comment = IssueComment.new
 
     @internal_comments = @issue.comments_visible_only_to_moderators

--- a/app/mailers/reporter_mailer.rb
+++ b/app/mailers/reporter_mailer.rb
@@ -1,0 +1,16 @@
+class ReporterMailer < ApplicationMailer
+
+  def notify_existing_account_of_issue
+    @project_name = params[:project_name]
+    @email = params[:email]
+    mail(to: @email, subject: "Beacon: Your attention is needed on a code of conduct issue")
+  end
+
+  def notify_new_account_of_issue
+    @project_name = params[:project_name]
+    @email = params[:email]
+    @url = params[:url]
+    mail(to: @email, subject: "Beacon: Your attention is needed on a code of conduct issue")
+  end
+
+end

--- a/app/models/issue_invitation.rb
+++ b/app/models/issue_invitation.rb
@@ -1,3 +1,3 @@
 class IssueInvitation < ApplicationRecord
-  attr_accessor :summary
+  attr_accessor :summary, :reporter_email
 end

--- a/app/views/issues/_moderator_view.html.erb
+++ b/app/views/issues/_moderator_view.html.erb
@@ -26,6 +26,22 @@
         <%= link_to "Details", project_reporter_path(@project, @issue.reporter.id), class: "btn btn-sm btn-warning" %>
       </li>
     </ul>
+    <% if @project.moderator?(@issue.reporter) %>
+      <p>
+        This issue was opened by a moderator on someone else's behalf. Use the
+        form below to invite a reporter. Note that the reporter must already
+        have an account in Beacon.
+      </p>
+      <%= form_for IssueInvitation.new, url: project_issue_issue_invitations_path(@project, @issue) do |f| %>
+        <div class="form-group">
+          <%= f.label "Reporter Email" %><br />
+          <%= f.text_field :reporter_email, class: "form-control" %>
+        </div>
+        <div class="actions">
+          <%= f.submit "Invite Reporter", class: "btn btn-primary" %>
+        </div>
+      <% end %>
+    <% end %>
 
     <h2 class="mt-3">
       Respondent

--- a/app/views/reporter_mailer/notify_existing_account_of_issue.html.inky
+++ b/app/views/reporter_mailer/notify_existing_account_of_issue.html.inky
@@ -1,0 +1,22 @@
+<% content_for :title do %>
+  Code of Conduct Enforcement Issue on <%= @project_name %>
+<% end %>
+
+<container style="margin-top: 2em;">
+  <row>
+    <columns>
+      <p>
+        A code of conduct issue has been filed in the <%= @project_name %> project on your behalf.
+      </p>
+      <p>
+        To view the issue and respond, please sign in to Beacon and click on 'My Issues' in the navigation bar.
+      </p>
+    </columns>
+  </row>
+
+  <row>
+    <columns>
+      <button href="<%= new_account_session_url %>">Sign In to Beacon</button>
+    </columns>
+  </row>
+</container>

--- a/app/views/reporter_mailer/notify_existing_account_of_issue.txt.erb
+++ b/app/views/reporter_mailer/notify_existing_account_of_issue.txt.erb
@@ -1,0 +1,7 @@
+Code of Conduct Enforcement Issue
+
+A code of conduct issue has been filed in the <%= @project_name %> project on your behalf.
+
+To view the issue, please sign in to Beacon and click on 'My Issues' in the navigation bar.
+
+Thank you in advance for your prompt response to this issue.


### PR DESCRIPTION
We welcome contributions involving code, documentation, or design. If you'd like to contribute, please check out [our guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

Please refer to our [contributing guidelines](https://github.com/ContributorCovenant/beacon/blob/release/CONTRIBUTING.md) and follow the guidance in that document to improve the chances of your PR being merged.

## Problem
Moderators can sometimes open an issue on behalf of someone else, but there is no way to assign a reporter after the issue has been opened.

## Solution
Allow moderators to invite a reporter to an issue.

## Todo
Any follow-up tasks that need to happen before or after the PR is merged.

## Notes for Reviewers
Anything that you want to tell the people who are going to review your pull request.

## Checklist
- [ ] Reasonable and adequate test coverage
- [ ] Requires a database migration
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`
