### PR TITLE
Make import from github work with private org membership

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -40,7 +40,12 @@ class OrganizationsController < ApplicationController
     render :show
   end
 
+  def github_auth_token
+    @token = current_account.github_token
+  end
+
   def import_projects_from_github
+    current_account.update_github_token(params[:token])
     results = GithubImportService.new(current_account, @organization).import_projects
     if results[:success]
       flash[:info] = "Successfully imported #{results[:count]} project(s)."
@@ -50,8 +55,13 @@ class OrganizationsController < ApplicationController
     redirect_to organization_path(@organization)
   end
 
+  def gitlab_auth_token
+    @token = current_account.gitlab_token
+  end
+
   def import_projects_from_gitlab
-    results = GitlabImportService.new(@organization, params[:oauth_token]).import_projects
+    current_account.update_gitlab_token(params[:token])
+    results = GitlabImportService.new(account, @organization).import_projects
     if results[:success]
       flash[:info] = "Successfully imported #{results[:count]} project(s)."
     else

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -40,6 +40,16 @@ class Account < ApplicationRecord
     self.email
   end
 
+  def github_token
+    return unless encrypted_token = credentials.find_by(provider: "github")&.token_encrypted
+    EncryptionService.decrypt(encrypted_token)
+  end
+
+  def gitlab_token
+    return unless encrypted_token = credentials.find_by(provider: "gitlab")&.token_encrypted
+    EncryptionService.decrypt(encrypted_token)
+  end
+
   def invitations
     Invitation.where(email: self.email)
   end
@@ -107,6 +117,16 @@ class Account < ApplicationRecord
 
   def total_issues_past_24_hours
     issues.select{ |issue| issue.created_at >= Time.zone.now - 24.hours }.size
+  end
+
+  def update_github_token(token)
+    return unless github_credentials = credentials.find_by(provider: "github")
+    github_credentials.update_attribute(:token_encrypted, EncryptionService.encrypt(token))
+  end
+
+  def update_gitlab_token(token)
+    return unless gitlab_credentials = credentials.find_by(provider: "gitlab")
+    gitlab_credentials.update_attribute(:token_encrypted, EncryptionService.encrypt(token))
   end
 
   private

--- a/app/services/gitlab_import_service.rb
+++ b/app/services/gitlab_import_service.rb
@@ -2,10 +2,10 @@ require 'gitlab'
 
 class GitlabImportService
 
-  attr_reader :oauth_token, :organization
+  attr_reader :account, :organization
 
-  def initialize(organization, oauth_token)
-    @oauth_token = oauth_token
+  def initialize(account, organization)
+    @account = account
     @organization = organization
   end
 
@@ -49,7 +49,7 @@ class GitlabImportService
   def client
     @client ||= Gitlab.client(
       endpoint: "https://gitlab.com/api/v4/",
-      private_token: oauth_token
+      private_token: account.gitlab_token
     )
   end
 

--- a/app/views/organizations/github_auth_token.html.erb
+++ b/app/views/organizations/github_auth_token.html.erb
@@ -1,0 +1,19 @@
+<% title "#{@organization.name}: Import from GitHub" %>
+
+<h1><%= @organization.name %>: Import Projects from GitHub</h1>
+
+<p>If you do not already have a GitHub token associated with your account, create
+a new token on GitHub through Settings&gt;Developer&gt;Personal Access Tokens.
+Check the box labeled "read:org" to add the required permissions.</p>
+
+<%= form_with url: organization_import_projects_from_github_path(@organization) do |f| %>
+  <div class="form-group col-sm-6">
+    <label for="token">OAuth Token</label><br />
+    <%= f.password_field :token, value: @token, class: "form-control" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Import", class: "btn btn-primary" %>
+    <%= link_to "Cancel", @organization, class: "btn btn-warning" %>
+  </div>
+<% end %>

--- a/app/views/organizations/gitlab_auth_token.html.erb
+++ b/app/views/organizations/gitlab_auth_token.html.erb
@@ -4,8 +4,8 @@
 
 <%= form_with url: organization_import_projects_from_gitlab_path(@organization) do |f| %>
   <div class="form-group col-sm-6">
-    <label for="oauth_token">OAuth_Token</label><br />
-    <%= f.text_field :oauth_token, class: "form-control" %>
+    <label for="token">OAuth Token</label><br />
+    <%= f.password_field :token, value: @token, class: "form-control" %>
   </div>
 
   <div class="actions">

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -68,7 +68,7 @@
   <div class="actions ml-3 mt-5 mb-3">
     <%= link_to "New Project", new_project_path(organization_id: @organization.id), class: "btn btn-primary" %>
     <% if current_account.credentials.find_by(provider: "github") %>
-      <%= link_to "Import Projects from GitHub", organization_import_projects_from_github_path(@organization), class: "btn btn-primary" %>
+      <%= link_to "Import Projects from GitHub", organization_github_auth_token_path(@organization), class: "btn btn-primary" %>
     <% end %>
     <% if current_account.credentials.find_by(provider: "gitlab") %>
       <%= link_to "Import Projects from GitLab", organization_gitlab_auth_token_path(@organization), class: "btn btn-primary" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,8 @@ Rails.application.routes.draw do
     get "import_projects_from_github", to: "organizations#import_projects_from_github"
     get "gitlab_auth_token", to: "organizations#gitlab_auth_token"
     post "import_projects_from_gitlab", to: "organizations#import_projects_from_gitlab"
+    get "github_auth_token", to: "organizations#github_auth_token"
+    post "import_projects_from_github", to: "organizations#import_projects_from_github"
     post "remove_moderator", to: "organizations#remove_moderator"
     patch "clone_ladder", to: "organizations#clone_ladder"
     post "clone_respondent_template", to: "respondent_templates#clone"

--- a/db/migrate/20190315230048_add_token_to_credentials.rb
+++ b/db/migrate/20190315230048_add_token_to_credentials.rb
@@ -1,0 +1,5 @@
+class AddTokenToCredentials < ActiveRecord::Migration[5.2]
+  def change
+    add_column :credentials, :token_encrypted, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_11_231942) do
+ActiveRecord::Schema.define(version: 2019_03_15_230048) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -144,6 +144,8 @@ ActiveRecord::Schema.define(version: 2019_03_11_231942) do
     t.string "uid"
     t.string "email"
     t.uuid "account_id"
+    t.string "oauth_token"
+    t.string "token_encrypted"
     t.index ["account_id"], name: "index_credentials_on_account_id"
     t.index ["provider", "uid"], name: "index_credentials_on_provider_and_uid", unique: true
   end
@@ -242,6 +244,10 @@ ActiveRecord::Schema.define(version: 2019_03_11_231942) do
     t.string "slug"
     t.text "description"
     t.uuid "account_id"
+    t.datetime "flagged_at"
+    t.text "flagged_reason"
+    t.datetime "confirmed_at"
+    t.string "confirmation_token_url"
     t.string "remote_org_name"
     t.index ["account_id"], name: "index_organizations_on_account_id"
   end


### PR DESCRIPTION
We welcome contributions involving code, documentation, or design. If you'd like to contribute, please check out [our guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

Please refer to our [contributing guidelines](https://github.com/ContributorCovenant/beacon/blob/release/CONTRIBUTING.md) and follow the guidance in that document to improve the chances of your PR being merged.

## Problem
If a group membership on GitHub was private, it was not possible to import projects from the organization page.

## Solution
Ask the user for an oauth token as part of the import process.

## Todo
Any follow-up tasks that need to happen before or after the PR is merged.

## Notes for Reviewers
Anything that you want to tell the people who are going to review your pull request.

## Checklist
- [ ] Reasonable and adequate test coverage
- [x] Requires a database migration
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`
