### PR TITLE
Allow ownership confirmation via oauth

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -62,6 +62,14 @@ class Account < ApplicationRecord
     @issues ||= AccountIssue.issues_for_account(id)
   end
 
+  def linked_to_github?
+    credentials.find_by(provider: "github").present?
+  end
+
+  def linked_to_gitlab?
+    credentials.find_by(provider: "gitlab").present?
+  end
+
   def notification_on_issue_of_kind?(issue_id, commenter_kind)
     issue_notifications = notifications.select{ |notification| notification.issue_id == issue_id }
     !issue_notifications.map(&:issue_comment).compact.find{ |comment| comment.commenter_kind == commenter_kind }.nil?

--- a/app/models/credential.rb
+++ b/app/models/credential.rb
@@ -16,11 +16,15 @@ class Credential < ApplicationRecord
     create(uid: auth.uid, provider: auth.provider, email: auth.info.email)
   end
 
+  def token
+    EncryptionService.decrypt(token_encrypted)
+  end
+
   private
 
   def provider_account_configuration
     return true if Account.omniauth_providers.include?(self.provider.to_sym)
-    errors.add(:provider, "This Provider is not configured")
+    errors.add(:provider, "This provider is not configured.")
   end
 
 end

--- a/app/services/project_confirmation_service.rb
+++ b/app/services/project_confirmation_service.rb
@@ -1,24 +1,39 @@
 class ProjectConfirmationService
 
-  attr_reader :project
+  attr_reader :project, :credential, :method
 
-  def self.confirm!(project)
-    new(project: project).confirm!
+  def self.confirm!(project, credential, method)
+    new(project, credential, method).confirm!
   end
 
-  def initialize(project:)
+  def initialize(project, credential, method)
     @project = project
+    @method = method
+    @credential = credential
   end
 
   def confirm!
-    return false unless confirm_via_oauth || confirm_via_token
+    if method == "github" || method == "gitlab"
+      confirmed = confirm_via_oauth
+    else
+      confirmed = confirm_via_token
+    end
+    return false unless confirmed
     project.update_attribute(:confirmed_at, DateTime.now)
   end
 
   private
 
-  # TODO: Use oauth to link account to GitHub or GitLab account and confirm project ownership
   def confirm_via_oauth
+    if method == "github"
+      return false unless repo = github_client.search_repositories(project.repo_name)
+      !!repo.fork?
+    elsif method == "gitlab"
+      return false unless repo = gitlab_client.project(project.repo_name)
+      !repo.respond_to?(:forked_from_project)
+    end
+  rescue StandardError => e
+    Rails.logger.info("Unable to verify via oauth for #{project.name}: #{e}")
     false
   end
 
@@ -29,6 +44,17 @@ class ProjectConfirmationService
   rescue StandardError => e
     Rails.logger.info("Unable to verify token for #{project.name}: #{e}")
     false
+  end
+
+  def github_client
+    Octokit::Client.new(access_token: credential.token)
+  end
+
+  def gitlab_client
+    Gitlab.client(
+      endpoint: "https://gitlab.com/api/v4/",
+      private_token: credential.token
+    )
   end
 
 end

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -11,7 +11,12 @@
   <div class="form-group col-sm-6">
     <%= f.label 'Project URL' %><br />
     <%= f.text_field :url, autofocus: true, class: "form-control" %>
-    <i>If you change your project's URL, you will have to re-verify your token.</i>
+  </div>
+
+  <div class="form-group col-sm-6">
+    <label for="project_repo_url">GitHub or GitLab URL</label><br />
+    <%= f.text_field :repo_url, class: "form-control" %>
+    <i>If you change this URL, you will have to re-verify your ownership.</i>
   </div>
 
   <div class="form-group col-sm-6">

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -17,6 +17,11 @@ settings for managing your project after it is created.</p>
   </div>
 
   <div class="form-group col-sm-6">
+    <label for="project_repo_url">GitHub or GitLab URL</label><br />
+    <%= f.text_field :repo_url, class: "form-control" %>
+  </div>
+
+  <div class="form-group col-sm-6">
     <%= f.label "Code of Conduct URL" %><br />
     <%= f.text_field :coc_url, class: "form-control" %>
   </div>

--- a/app/views/projects/ownership.html.erb
+++ b/app/views/projects/ownership.html.erb
@@ -1,29 +1,58 @@
 <% title "#{@project.name}: Ownership Confirmation" %>
 
-<h1><%= @project.name %>: Ownership Confirmation</h1>
+<h1><%= link_to @project.name, @project %>: Ownership Confirmation</h1>
 
 <p>To confirm ownership of this project, create a file at the designated URL with the following contents:</p>
 
 <%= form_for @project, url: project_confirm_path(@project) do |f| %>
-
   <div class="form-group">
     <%= f.label :token, "Confirmation Token" %>
     <%= f.text_field :token, value: "BEACON_TOKEN=#{@project.confirmation_token}", disabled: true, class: "form-control" %>
   </div>
-
   <div class="form-group">
     <%= f.label :confirmation_token_url, "Confirmation Token URL" %>
     <%= f.text_field :confirmation_token_url, value: (@project.confirmation_token_url || @project.confirmation_token_url_default), class: "form-control" %>
   </div>
-
   <div class="actions">
     <% if @project.confirmed_at.present? %>
       <%= f.submit "Re-Verify Ownership", class: "btn btn-primary" %>
     <% else %>
       <%= f.submit "Verify Ownership", class: "btn btn-primary" %>
     <% end %>
+    <%= link_to "Cancel", @project, class: "btn btn-warning" %>
   </div>
-
 <% end %>
 
-<p class="mt-3">Alternately, <a href="#">connect your account</a> to GitHub or GitLab to verify ownership of your repository.</p>
+<p class="mt-5">If <%= link_to "your account is linked", edit_account_path(current_account) %>
+to GitHub or GitLab, you can use an oauth token to confirm.</p>
+
+<% if current_account.linked_to_github? %>
+  <h2>Confirm GitHub Project</h2>
+  <p>Provide a <a href="https://github.com/settings/tokens/new" target="_new">personal access token</a>
+  with "public_repo" permissions.</p>
+  <%= form_for @project, url: project_confirm_path(@project) do |f| %>
+    <div class="form-group col-sm-6">
+      <label for="token">OAuth Token</label><br />
+      <%= f.password_field :token, value: current_account.github_token, class: "form-control" %>
+    </div>
+    <div class="actions">
+      <%= f.submit "Confirm via GitHub", class: "btn btn-primary" %>
+      <%= link_to "Cancel", @project, class: "btn btn-warning" %>
+    </div>
+  <% end %>
+  <br />
+<% end %>
+
+<% if current_account.linked_to_gitlab? %>
+  <h2>Confirm GitLab Project</h2>
+  <%= form_for @project, url: project_confirm_path(@project) do |f| %>
+    <div class="form-group col-sm-6">
+      <label for="token">OAuth Token</label><br />
+      <%= f.password_field :token, value: current_account.gitlab_token, class: "form-control" %>
+    </div>
+    <div class="actions">
+      <%= f.submit "Confirm via GitLab", class: "btn btn-primary" %>
+      <%= link_to "Cancel", @project, class: "btn btn-warning" %>
+    </div>
+  <% end %>
+<% end %>

--- a/db/migrate/20190316205109_add_repo_url_to_projects.rb
+++ b/db/migrate/20190316205109_add_repo_url_to_projects.rb
@@ -1,0 +1,5 @@
+class AddRepoUrlToProjects < ActiveRecord::Migration[5.2]
+  def change
+    add_column :projects, :repo_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_15_230048) do
+ActiveRecord::Schema.define(version: 2019_03_16_205109) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -292,6 +292,7 @@ ActiveRecord::Schema.define(version: 2019_03_15_230048) do
     t.boolean "setup_complete", default: false
     t.uuid "organization_id"
     t.string "confirmation_token_url"
+    t.string "repo_url"
     t.index ["account_id"], name: "index_projects_on_account_id"
     t.index ["organization_id"], name: "index_projects_on_organization_id"
     t.index ["slug"], name: "index_projects_on_slug", unique: true


### PR DESCRIPTION
We welcome contributions involving code, documentation, or design. If you'd like to contribute, please check out [our guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

Please refer to our [contributing guidelines](https://github.com/ContributorCovenant/beacon/blob/release/CONTRIBUTING.md) and follow the guidance in that document to improve the chances of your PR being merged.

## Problem
Project owners should be able to confirm project ownership via oauth token.

## Solution
Enable oauth project ownership verification.

## Todo
Any follow-up tasks that need to happen before or after the PR is merged.

## Notes for Reviewers
Anything that you want to tell the people who are going to review your pull request.

## Checklist
- [ ] Reasonable and adequate test coverage
- [x] Requires a database migration
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`
