### PR TITLE
Post-resolution survey to reporters and respondents

### DIFF
--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -1,0 +1,55 @@
+class SurveysController < ApplicationController
+
+  before_action :scope_project
+  before_action :scope_issue
+  before_action :enforce_permissions
+
+  def new
+    @survey = Survey.new
+  end
+
+  def create
+    @survey = Survey.new(
+      survey_params.merge(
+        project_id: @project.id,
+        issue_id: @issue.id,
+        account_id: current_account.id
+      )
+    )
+    if @survey.save
+      flash[:info] = "Thank you for completing the survey."
+      redirect_to project_issue_path(@project, @issue)
+    else
+      flash[:error] = @survey.errors.full_messages
+      render :new
+    end
+  end
+
+  private
+
+  def enforce_permissions
+    render_forbidden && return unless current_account.can_complete_survey_on_issue?(@issue, @project)
+  end
+
+  def scope_issue
+    @issue = Issue.find(params[:issue_id])
+  end
+
+  def scope_project
+    @project = Project.find_by(slug: params[:project_slug])
+  end
+
+  def survey_params
+    params.require(:survey).permit(
+      :project_id,
+      :issue_id,
+      :responsiveness,
+      :sensitivity,
+      :fairness,
+      :community,
+      :would_recommend,
+      :recommendation_note
+    )
+  end
+
+end

--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -1,5 +1,6 @@
 class SurveysController < ApplicationController
 
+  before_action :authenticate_account!
   before_action :scope_project
   before_action :scope_issue
   before_action :enforce_permissions

--- a/app/models/concerns/permissions.rb
+++ b/app/models/concerns/permissions.rb
@@ -36,6 +36,11 @@ module Permissions
     !is_flagged
   end
 
+  def can_complete_survey_on_issue?(issue, project)
+    return false unless issue.respondent == self || issue.reporter == self
+    return !project.surveys.map(&:account).find{ |account| account == self }.present?
+  end
+
   def can_invite_respondent?(issue)
     issue.project.moderator?(self)
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -16,6 +16,7 @@ class Project < ApplicationRecord
   has_many :project_issues, dependent: :destroy
   has_many :roles, dependent: :destroy
   has_many :moderators, through: :roles, source: :account
+  has_many :surveys
 
   before_create :set_slug
   after_create :make_settings

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -1,0 +1,28 @@
+class Survey < ApplicationRecord
+
+  attr_accessor :account_id, :issue_id
+
+  belongs_to :project
+
+  before_save :encrypt_account_id
+  before_save :encrypt_issue_id
+
+  def account
+    Account.find(EncryptionService.decrypt(self.account_encrypted_id))
+  end
+
+  def issue
+    Issue.find(EncryptionService.decrypt(issue_encrypted_id))
+  end
+
+  private
+
+  def encrypt_account_id
+    self.account_encrypted_id = EncryptionService.encrypt(account_id)
+  end
+
+  def encrypt_issue_id
+    self.issue_encrypted_id = EncryptionService.encrypt(issue_id)
+  end
+
+end

--- a/app/views/issue_notifications_mailer/notify_on_status_change.html.inky
+++ b/app/views/issue_notifications_mailer/notify_on_status_change.html.inky
@@ -11,7 +11,15 @@
 
   <row>
     <columns>
-      <button href="<%= project_issue_url(@project, @issue) %>">View Issue</button>
+      <% if @issue.resolved? %>
+        <p>
+          The moderators would like you to complete a brief survey about your feelings about how
+          the issue was handled.
+        </p>
+        <button href="<%= new_project_issue_survey_url(@project, @issue) %>">View Issue</button>
+      <% else %>
+        <button href="<%= project_issue_url(@project, @issue) %>">View Issue</button>
+      <% end %>
     </columns>
   </row>
 </container>

--- a/app/views/issue_notifications_mailer/notify_on_status_change.txt.erb
+++ b/app/views/issue_notifications_mailer/notify_on_status_change.txt.erb
@@ -3,9 +3,18 @@ Update to #{@project.name} Issue ##{@issue.issue_number}
 
 This issue's status was updated to <%= @issue.aasm_state.titleize %> by a moderator.
 
-You can view the issue in Beacon at this URL for updates:
+<% if @issue.resolved? %>
+  <p>
+    The moderators would like you to complete a brief survey about your feelings about how
+    the issue was handled.
 
-  <%= project_issue_url(@project, @issue) %>
+    <%= new_project_issue_survey_url(@project, @issue) %>
+
+<% else %>
+  You can view the issue in Beacon at this URL for updates:
+
+    <%= project_issue_url(@project, @issue) %>
+<% end %>
 
 Thank you,
 The Friendly Beacon Mailer Robot

--- a/app/views/issues/_reporter_view.html.erb
+++ b/app/views/issues/_reporter_view.html.erb
@@ -7,6 +7,12 @@
         <%= @issue.description %>
       </div>
     </div>
+
+    <% if @issue.resolved? && current_account.can_complete_survey_on_issue?(@issue, @project) %>
+      <h2>Feedback</h2>
+      <p>Would you like to complete a short survey on the resolution of this issue?</p>
+      <%= link_to "Take Survey", new_project_issue_survey_path(@project, @issue), class: "btn btn-primary" %>
+    <% end %>
   </div>
 
   <div class="col">

--- a/app/views/issues/_respondent_view.html.erb
+++ b/app/views/issues/_respondent_view.html.erb
@@ -1,10 +1,16 @@
+<h2 class="mt-3">Description</h2>
+<p><%= @issue.respondent_summary %></p>
+
 <h2 class="mt-3">Status</h2>
 <p>
   <%= issue.aasm_state.titleize %> (<%= issue.updated_at.in_time_zone.strftime("%a %b %d %Y at %l:%M %p %Z") %>)
 </p>
 
-<h2 class="mt-3">Description</h2>
-<p><%= @issue.respondent_summary %></p>
+<% if @issue.resolved? && current_account.can_complete_survey_on_issue?(@issue, @project) %>
+  <h2>Feedback</h2>
+  <p>Would you like to complete a short survey on the resolution of this issue?</p>
+  <%= link_to "Take Survey", new_project_issue_survey_path(@project, @issue), class: "btn btn-primary" %>
+<% end %>
 
 <h2 class="mt-3">Discussion with Moderators</h2>
 
@@ -37,4 +43,3 @@
     <%= f.submit "Send Message", class: "btn btn-primary" %>
   </div>
 <% end %>
-

--- a/app/views/surveys/new.html.erb
+++ b/app/views/surveys/new.html.erb
@@ -1,0 +1,44 @@
+<% title "#{@project.name} Satisfaction Survey" %>
+
+<h1>Issue Resolution Satisfaction Survey</h1>
+<p>You can improve the experience for other participants in code of conduct issues for
+this project by providing feedback to the moderators.</p>
+
+<%= form_for @survey, url: project_issue_surveys_path do |f| %>
+
+  <div class="form-group col-sm-6">
+  <%= f.label :responsiveness, "Do you feel that the moderators were responsive?" %><br />
+  <%= f.select :responsiveness, options_for_select([["Yes", true], ["No", false]]), include_blank: "Select...", class: "form-control" %>
+  </div>
+
+  <div class="form-group col-sm-6">
+  <%= f.label :sensitivity, "Do you feel that the moderators were sensitive to your situation?" %><br />
+  <%= f.select :sensitivity, options_for_select([["Yes", true], ["No", false]]), include_blank: "Select...", class: "form-control" %>
+  </div>
+
+  <div class="form-group col-sm-6">
+    <%= f.label :fairness, "Do you feel that the moderators were fair?" %><br />
+    <%= f.select :fairness, options_for_select([["Yes", true], ["No", false]]), include_blank: "Select...", class: "form-control" %>
+  </div>
+
+  <div class="form-group col-sm-6">
+    <%= f.label :community, "Do you feel that the moderators acted in the best interests of the community?" %><br />
+    <%= f.select :community, options_for_select([["Yes", true], ["No", false]]), include_blank: "Select...", class: "form-control" %>
+  </div>
+
+  <div class="form-group col-sm-6">
+    <%= f.label :would_recommend, "How likely would you be to recommend someone opening an issue on this project for a future code of conduct violation? (0 = strong 'no', 10 = strong 'yes')" %><br />
+    <%= f.select :would_recommend, (0..10).to_a, include_blank: "Select...", class: "form-control" %>
+  </div>
+
+  <div class="form-group col-sm-6">
+    <%= f.label :recommendation_note, "Why or why not?" %><br />
+    <%= f.text_area :recommendation_note, rows: 5, style: "width: 100%" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Submit Survey", class: "btn btn-primary" %>
+    <%= link_to "Cancel", project_issue_path(@project, @issue), class: "btn btn-warning" %>
+  </div>
+
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,15 +13,19 @@ Rails.application.routes.draw do
   get "about", to: "static_content#about"
   get "user_guides", to: "static_content#guide"
 
+  resources :abuse_reports, only: [:new, :create]
+
   resources :accounts
 
-  resources :abuse_reports, only: [:new, :create]
   resources :contact_messages, only: [:new, :create]
+
   resources :invitations, only: [:create, :index] do
     post "accept", to: "invitations#accept"
     post "reject", to: "invitations#reject"
   end
+
   resources :issues
+
   resources :organizations, param: :slug do
     resources :invitations, only: [:create]
     resources :issue_severity_levels
@@ -37,23 +41,27 @@ Rails.application.routes.draw do
     post "clone_respondent_template", to: "respondent_templates#clone"
     patch "clone_respondent_template", to: "respondent_templates#clone"
   end
+
   resources :projects, param: :slug do
     resources :account_project_blocks
     resources :invitations, only: [:create]
     resources :issues do
-      resources :uploads
       resources :issue_comments, only: [:create, :new]
       resources :issue_invitations, only: [:create, :new]
+      resources :surveys, only: [:create, :new]
+      resources :uploads
       post "acknowledge", to: "issues#acknowledge"
       post "dismiss", to: "issues#dismiss"
       patch "resolve", to: "issues#resolve"
       post "reopen", to: "issues#reopen"
     end
+
     resources :issue_severity_levels
     resources :invitations, only: [:new, :create]
     resources :reporters, only: [:show]
     resources :respondent_templates, only: [:new, :create, :edit, :update, :show]
     resources :respondents, only: [:show]
+
     get "settings", to: "project_settings#edit"
     get "moderators", to: "projects#moderators"
     get "ownership", to: "projects#ownership"

--- a/db/migrate/20190317181358_create_survey.rb
+++ b/db/migrate/20190317181358_create_survey.rb
@@ -1,0 +1,16 @@
+class CreateSurvey < ActiveRecord::Migration[5.2]
+  def change
+    create_table :surveys, id: :uuid do |t|
+      t.references :project, type: :uuid, foreign_key: true
+      t.string :issue_encrypted_id
+      t.string :account_encrypted_id
+      t.boolean :fairness
+      t.boolean :responsiveness
+      t.boolean :sensitivity
+      t.boolean :community
+      t.integer :would_recommend
+      t.text :recommendation_note
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_17_010218) do
+ActiveRecord::Schema.define(version: 2019_03_17_181358) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -144,6 +144,7 @@ ActiveRecord::Schema.define(version: 2019_03_17_010218) do
     t.string "uid"
     t.string "email"
     t.uuid "account_id"
+    t.string "oauth_token"
     t.string "token_encrypted"
     t.index ["account_id"], name: "index_credentials_on_account_id"
     t.index ["provider", "uid"], name: "index_credentials_on_provider_and_uid", unique: true
@@ -243,6 +244,10 @@ ActiveRecord::Schema.define(version: 2019_03_17_010218) do
     t.string "slug"
     t.text "description"
     t.uuid "account_id"
+    t.datetime "flagged_at"
+    t.text "flagged_reason"
+    t.datetime "confirmed_at"
+    t.string "confirmation_token_url"
     t.string "remote_org_name"
     t.datetime "created_at", default: "2019-03-16 00:00:00"
     t.datetime "updated_at", default: "2019-03-16 00:00:00"
@@ -323,6 +328,21 @@ ActiveRecord::Schema.define(version: 2019_03_17_010218) do
     t.index ["project_id"], name: "index_roles_on_project_id"
   end
 
+  create_table "surveys", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "project_id"
+    t.string "issue_encrypted_id"
+    t.string "account_encrypted_id"
+    t.boolean "fairness"
+    t.boolean "responsiveness"
+    t.boolean "sensitivity"
+    t.boolean "community"
+    t.integer "would_recommend"
+    t.text "recommendation_note"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["project_id"], name: "index_surveys_on_project_id"
+  end
+
   create_table "suspicious_activity_logs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "controller"
     t.string "action"
@@ -363,5 +383,6 @@ ActiveRecord::Schema.define(version: 2019_03_17_010218) do
   add_foreign_key "roles", "accounts"
   add_foreign_key "roles", "organizations"
   add_foreign_key "roles", "projects"
+  add_foreign_key "surveys", "projects"
   add_foreign_key "suspicious_activity_logs", "accounts"
 end


### PR DESCRIPTION
We welcome contributions involving code, documentation, or design. If you'd like to contribute, please check out [our guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

Please refer to our [contributing guidelines](https://github.com/ContributorCovenant/beacon/blob/release/CONTRIBUTING.md) and follow the guidance in that document to improve the chances of your PR being merged.

## Problem
We want to provide feedback and collect statistics on issue resolution from the point of view of reporters and respondents.

## Solution
Create a survey that is sent to reporters and respondents on issue resolution.

## Todo
Any follow-up tasks that need to happen before or after the PR is merged.

## Notes for Reviewers
Anything that you want to tell the people who are going to review your pull request.

## Checklist
- [x] Reasonable and adequate test coverage
- [x] Requires a database migration
- [x] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`