### PR TITLE
Moderator notifications and view of surveys

### DIFF
--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -47,6 +47,7 @@ class IssuesController < ApplicationController
   def show
     @invitation = IssueInvitation.new
     @comment = IssueComment.new
+    @surveys = @project.surveys
 
     @internal_comments = @issue.comments_visible_only_to_moderators
     @reporter_discussion_comments = @issue.comments_visible_to_reporter

--- a/app/mailers/issue_notifications_mailer.rb
+++ b/app/mailers/issue_notifications_mailer.rb
@@ -22,4 +22,13 @@ class IssueNotificationsMailer < ApplicationMailer
     mail(to: @email, subject: "Beacon: #{@project.name} Issue ##{@issue.issue_number} issue has a new comment")
   end
 
+  def notify_of_new_survey
+    @project = params[:project]
+    @issue = params[:issue]
+    @survey = params[:survey]
+    @kind = @survey.kind
+    @email = params[:email]
+    mail(to: @email, subject: "Beacon: #{@project.name} Issue ##{@issue.issue_number} issue has a new survey")
+  end
+
 end

--- a/app/models/concerns/permissions.rb
+++ b/app/models/concerns/permissions.rb
@@ -110,4 +110,10 @@ module Permissions
     false
   end
 
+  def can_view_survey_on_issue?(project)
+    return true if is_admin?
+    return true if project.moderators.include?(self)
+    false
+  end
+
 end

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -7,12 +7,15 @@ class Survey < ApplicationRecord
   before_save :encrypt_account_id
   before_save :encrypt_issue_id
 
+  scope :reporter, -> { where(kind: "reporter") }
+  scope :respondent, -> { where(kind: "respondent") }
+
   def account
-    Account.find(EncryptionService.decrypt(self.account_encrypted_id))
+    @account ||= Account.find(EncryptionService.decrypt(self.account_encrypted_id))
   end
 
   def issue
-    Issue.find(EncryptionService.decrypt(issue_encrypted_id))
+    @issue ||= Issue.find(EncryptionService.decrypt(issue_encrypted_id))
   end
 
   private

--- a/app/views/issue_notifications_mailer/notify_of_new_survey.html.inky
+++ b/app/views/issue_notifications_mailer/notify_of_new_survey.html.inky
@@ -1,0 +1,19 @@
+<% content_for :title do %>
+  New survey submitted for <%= @project.name %> Issue #<%= @issue.issue_number %>
+<% end %>
+
+<container style="margin-top: 2em;">
+  <row>
+    <columns>
+      <p>
+        The <%= @kind %> submitted a satisfaction survey for this issue.
+      </p>
+    </columns>
+  </row>
+
+  <row>
+    <columns>
+      <button href="<%= project_issue_survey_url(@project, @issue, @survey) %>">View Survey</button>
+    </columns>
+  </row>
+</container>

--- a/app/views/issue_notifications_mailer/notify_of_new_survey.txt.erb
+++ b/app/views/issue_notifications_mailer/notify_of_new_survey.txt.erb
@@ -1,0 +1,10 @@
+New survey on <%= @project.name %>: Issue #<%= @issue.issue_number %>
+------------------------------------------------------------------------
+
+A new satisfaction survey for <%= @project.name %> issue #<%= @issue.issue_number %>
+has been submitted by a <%= @kind %>. You can view the survey in Beacon at this URL:
+
+  <%= project_issue_survey_url(@project, @issue, @survey) %>
+
+Thank you,
+The Friendly Beacon Mailer Robot

--- a/app/views/issues/_moderator_view.html.erb
+++ b/app/views/issues/_moderator_view.html.erb
@@ -117,19 +117,19 @@
 
   <div class="nav nav-tabs mt-5 mb-3" id="nav-tab" role="tablist" style="width: 100%;">
     <a class="nav-link active" id="nav-internal-discussion-tab" data-toggle="pill" href="#nav-internal-discussion" role="tab" aria-controls="nav-internal-discussion" aria-selected="true">
-      Moderator Discussion
+      Moderator Talk
       <% if @notifications_for_internal_comments_count > 0 %>
         <span class="badge badge-pill badge-danger"><%= @notifications_for_internal_comments_count %></span>
       <% end %>
     </a>
     <a class="nav-link " id="nav-reporter-discussion-tab" data-toggle="pill" href="#nav-reporter-discussion" role="tab" aria-controls="nav-reporter-discussion" aria-selected="false">
-      Reporter Discussion
+      Reporter Talk
       <% if @notifications_for_reporter_comments_count > 0 %>
         <span class="badge badge-pill badge-danger"><%= @notifications_for_reporter_comments_count %></span>
       <% end %>
     </a>
     <a class="nav-link " id="nav-respondent-discussion-tab" data-toggle="pill" href="#nav-respondent-discussion" role="tab" aria-controls="nav-respondent-discussion" aria-selected="false">
-      Respondent Discussion
+      Respondent Talk
       <% if @notifications_for_respondent_comments_count > 0 %>
         <span class="badge badge-pill badge-danger"><%= @notifications_for_respondent_comments_count %></span>
       <% end %>
@@ -140,6 +140,11 @@
     <a class="nav-link " id="nav-resolution-tab" data-toggle="pill" href="#nav-resolution" role="tab" aria-controls="nav-resolution" aria-selected="false">
       Resolution
     </a>
+    <% if @surveys.any? %>
+      <a class="nav-link " id="nav-surveys-tab" data-toggle="pill" href="#nav-surveys" role="tab" aria-controls="nav-surveys" aria-selected="false">
+        Surveys
+      </a>
+    <% end %>
     <a class="nav-link " id="nav-history-tab" data-toggle="pill" href="#nav-history" role="tab" aria-controls="nav-history" aria-selected="false">
       Issue History
     </a>
@@ -266,6 +271,17 @@
           </div>
         </div>
       <% end %>
+    </div>
+
+    <div class="tab-pane fade" id="nav-surveys" role="tabpanel" aria-labelledby="nav-surveys-tab">
+      <ul>
+        <% @surveys.each do |survey| %>
+          <li>
+            <% kind = survey.account == @issue.reporter ? "Reporter Survey" : "Respondent Survey" %>
+            <%= link_to kind, project_issue_survey_path(@project, @issue, survey) %>
+          </li>
+        <% end %>
+      </ul>
     </div>
 
     <div class="tab-pane fade" id="nav-history" role="tabpanel" aria-labelledby="nav-history-tab">

--- a/app/views/surveys/show.html.erb
+++ b/app/views/surveys/show.html.erb
@@ -1,0 +1,46 @@
+<% title "Issue ##{@issue.issue_number}:  Satisfaction Survey" %>
+
+<h1>
+  <%= link_to @project.name, @project %>: Issue <%= link_to @issue.issue_number, project_issue_path(@project, @issue) %>:
+  <%= @survey.kind %> Satisfaction Survey</h1>
+</h1>
+
+<ol>
+  <li>
+    Do you feel that the moderators were responsive?<br />
+    <% badge_class = @survey.responsiveness ? 'badge-warning' : 'badge-danger' %>
+    <span class="badge badge-pill <%= badge_class %>"><%= @survey.responsiveness ? "Yes" : "No" %></span>
+  </li>
+
+  <li>
+  Do you feel that the moderators were sensitive to your situation?<br />
+  <% badge_class = @survey.sensitivity ? 'badge-warning' : 'badge-danger' %>
+  <span class="badge badge-pill <%= badge_class %>"><%= @survey.sensitivity ? "Yes" : "No" %></span>
+  </li>
+
+  <li>
+    Do you feel that the moderators were fair?<br />
+    <% badge_class = @survey.fairness ? 'badge-warning' : 'badge-danger' %>
+    <span class="badge badge-pill <%= badge_class %>"><%= @survey.fairness ? "Yes" : "No" %></span>
+  </li>
+
+  <li>
+    Do you feel that the moderators acted in the best interests of the community?<br />
+    <% badge_class = @survey.community ? 'badge-warning' : 'badge-danger' %>
+    <span class="badge badge-pill <%= badge_class %>"><%= @survey.community ? "Yes" : "No" %></span>
+  </li>
+
+  <li>
+    How likely would you be to recommend someone opening an issue on this project for a future code of conduct violation?<br />
+    (0 = strong 'no', 10 = strong 'yes')<br />
+    <% badge_class = @survey.would_recommend.to_i > 6 ? 'badge-warning' : 'badge-danger' %>
+    <span class="badge badge-pill <%= badge_class %>"><%= @survey.would_recommend %></span>
+  </li>
+
+  <li>
+    Why or why not?<br />
+    <%= @survey.recommendation_note %>
+  </li>
+</ol>
+
+<%= link_to "Done", :back, class: "btn btn-primary" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,7 +48,7 @@ Rails.application.routes.draw do
     resources :issues do
       resources :issue_comments, only: [:create, :new]
       resources :issue_invitations, only: [:create, :new]
-      resources :surveys, only: [:create, :new]
+      resources :surveys, only: [:create, :new, :show]
       resources :uploads
       post "acknowledge", to: "issues#acknowledge"
       post "dismiss", to: "issues#dismiss"

--- a/db/migrate/20190317213501_add_kind_to_survey.rb
+++ b/db/migrate/20190317213501_add_kind_to_survey.rb
@@ -1,0 +1,5 @@
+class AddKindToSurvey < ActiveRecord::Migration[5.2]
+  def change
+    add_column :surveys, :kind, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_17_181358) do
+ActiveRecord::Schema.define(version: 2019_03_17_213501) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -340,6 +340,7 @@ ActiveRecord::Schema.define(version: 2019_03_17_181358) do
     t.text "recommendation_note"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "kind"
     t.index ["project_id"], name: "index_surveys_on_project_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -144,7 +144,6 @@ ActiveRecord::Schema.define(version: 2019_03_17_213501) do
     t.string "uid"
     t.string "email"
     t.uuid "account_id"
-    t.string "oauth_token"
     t.string "token_encrypted"
     t.index ["account_id"], name: "index_credentials_on_account_id"
     t.index ["provider", "uid"], name: "index_credentials_on_provider_and_uid", unique: true
@@ -244,13 +243,9 @@ ActiveRecord::Schema.define(version: 2019_03_17_213501) do
     t.string "slug"
     t.text "description"
     t.uuid "account_id"
-    t.datetime "flagged_at"
-    t.text "flagged_reason"
-    t.datetime "confirmed_at"
-    t.string "confirmation_token_url"
     t.string "remote_org_name"
-    t.datetime "created_at", default: "2019-03-16 00:00:00"
-    t.datetime "updated_at", default: "2019-03-16 00:00:00"
+    t.datetime "created_at", default: "2019-03-17 00:00:00"
+    t.datetime "updated_at", default: "2019-03-17 00:00:00"
     t.boolean "is_flagged", default: false
     t.index ["account_id"], name: "index_organizations_on_account_id"
   end

--- a/spec/features/moderator_spec.rb
+++ b/spec/features/moderator_spec.rb
@@ -62,7 +62,7 @@ describe "moderation", type: :feature do
       visit projects_path
       click_on project.name
       click_on issue.issue_number
-      expect(page).to have_content("Reporter Discussion 1")
+      expect(page).to have_content("Reporter Talk 1")
     end
 
   end
@@ -163,7 +163,7 @@ describe "moderation", type: :feature do
     end
 
     it "allows the moderator to send a message to other moderators" do
-      click_on "Moderator Discussion"
+      click_on "Moderator Talk"
       within("#nav-internal-discussion") do
         fill_in("issue_comment_text", with: "Sarah, what do you think?")
       end
@@ -182,7 +182,7 @@ describe "moderation", type: :feature do
     end
 
     it "allows the moderator to send a message to a reporter" do
-      click_on "Reporter Discussion"
+      click_on "Reporter Talk"
       within("#nav-reporter-discussion") do
         fill_in("issue_comment_text", with: "Can you provide some more details?")
       end
@@ -237,7 +237,7 @@ describe "moderation", type: :feature do
       end
 
       it "allows the moderator to send a message to a respondent" do
-        click_on "Respondent Discussion"
+        click_on "Respondent Talk"
         within("#nav-respondent-discussion") do
           fill_in("issue_comment_text", with: "When are you free to discuss this?")
         end


### PR DESCRIPTION
We welcome contributions involving code, documentation, or design. If you'd like to contribute, please check out [our guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

Please refer to our [contributing guidelines](https://github.com/ContributorCovenant/beacon/blob/release/CONTRIBUTING.md) and follow the guidance in that document to improve the chances of your PR being merged.

## Problem
Moderators should be informed of completed reporter/respondent satisfaction surveys, and have the ability to view them.

## Solution
Send email notifications on survey completion. Add a 'Surveys' tab to issue details pages.

## Todo
Any follow-up tasks that need to happen before or after the PR is merged.

## Notes for Reviewers
Anything that you want to tell the people who are going to review your pull request.

## Checklist
- [x] Reasonable and adequate test coverage
- [x] Requires a database migration
- [x] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`