### PR TITLE
Publish project health stats in directory

### DIFF
--- a/app/controllers/directory_controller.rb
+++ b/app/controllers/directory_controller.rb
@@ -11,6 +11,7 @@ class DirectoryController < ApplicationController
   def show
     if @project = Project.for_directory.find_by(slug: params[:slug])
       @issue_severity_levels = @project.issue_severity_levels
+      @report = TransparencyReportingService.new(@project)
     else
       redirect_to directory_path
     end

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -47,7 +47,7 @@ class IssuesController < ApplicationController
   def show
     @invitation = IssueInvitation.new
     @comment = IssueComment.new
-    @surveys = @project.surveys
+    @surveys = @project.surveys.select{ |s| s.issue == @issue }
 
     @internal_comments = @issue.comments_visible_only_to_moderators
     @reporter_discussion_comments = @issue.comments_visible_to_reporter

--- a/app/models/concerns/permissions.rb
+++ b/app/models/concerns/permissions.rb
@@ -38,7 +38,7 @@ module Permissions
 
   def can_complete_survey_on_issue?(issue, project)
     return false unless issue.respondent == self || issue.reporter == self
-    return !project.surveys.map(&:account).find{ |account| account == self }.present?
+    return !project.surveys.select{ |s| s.issue == issue }.map(&:account).find{ |account| account == self }.present?
   end
 
   def can_invite_respondent?(issue)

--- a/app/services/transparency_reporting_service.rb
+++ b/app/services/transparency_reporting_service.rb
@@ -31,7 +31,7 @@ class TransparencyReportingService
   end
 
   def suitable_for_public?
-    reporter_surveys.size > 2
+    reporter_surveys.size >= 2
   end
 
   def net_promoter_score

--- a/app/views/directory/show.html.erb
+++ b/app/views/directory/show.html.erb
@@ -62,11 +62,21 @@
       <% end %>
     </ul>
 
-    <% if @project.project_setting.publish_stats? %>
-      <h2 class="mt-5">3-Month Activity</h2>
-      <p><span class="badge badge-pill badge-primary">90%</span> reporter satisfaction with issue resolution</p>
-      <p><span class="badge badge-pill badge-primary">75%</span> respondent satisfaction with issue resolution</p>
-      <p><span class="badge badge-pill badge-primary">4 days</span> on average to resolve an issue</p>
+    <% if @project.show_transparency_report? && @report.suitable_for_public? %>
+      <h2 class="mt-5">Project Health</h2>
+      <ul>
+        <% if @report.average_time_to_resolution.present? %>
+          <li>
+            Average issue resolution: <%= @report.average_time_to_resolution %> days
+          </li>
+        <% end %>
+        <li>
+          Overall satisfaction: <%= @report.net_promoter_score %>
+        </li>
+        <li>
+          Overall project health: <%= @report.health %>
+        </li>
+      </ul>
     <% end %>
 
     <% if current_account %>

--- a/app/views/directory/show.html.erb
+++ b/app/views/directory/show.html.erb
@@ -63,7 +63,7 @@
     </ul>
 
     <% if @project.show_transparency_report? && @report.suitable_for_public? %>
-      <h2 class="mt-5">Project Health</h2>
+      <h2 class="mt-4">Project Health</h2>
       <ul>
         <% if @report.average_time_to_resolution.present? %>
           <li>

--- a/app/views/surveys/show.html.erb
+++ b/app/views/surveys/show.html.erb
@@ -2,7 +2,7 @@
 
 <h1>
   <%= link_to @project.name, @project %>: Issue <%= link_to @issue.issue_number, project_issue_path(@project, @issue) %>:
-  <%= @survey.kind %> Satisfaction Survey</h1>
+  <%= @survey.kind.titleize %> Satisfaction Survey</h1>
 </h1>
 
 <ol>

--- a/spec/models/concerns/permissions_spec.rb
+++ b/spec/models/concerns/permissions_spec.rb
@@ -175,6 +175,7 @@ RSpec.describe Permissions do
     context "reporters who have already submitted a survey" do
       before do
         allow_any_instance_of(Survey).to receive(:account).and_return(exene)
+        allow_any_instance_of(Survey).to receive(:issue).and_return(issue)
         allow_any_instance_of(Project).to receive(:surveys).and_return([survey])
       end
       it "does not allow" do
@@ -185,6 +186,7 @@ RSpec.describe Permissions do
     context "respondents who have already submitted a survey" do
       before do
         allow_any_instance_of(Survey).to receive(:account).and_return(donnie)
+        allow_any_instance_of(Survey).to receive(:issue).and_return(issue)
         allow_any_instance_of(Project).to receive(:surveys).and_return([survey])
       end
       it "does not allow" do


### PR DESCRIPTION
We welcome contributions involving code, documentation, or design. If you'd like to contribute, please check out [our guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

Please refer to our [contributing guidelines](https://github.com/ContributorCovenant/beacon/blob/release/CONTRIBUTING.md) and follow the guidance in that document to improve the chances of your PR being merged.

## Problem
People browsing the directory should be able to get a sense of how responsive and fair moderators are when dealing with issues in a given project.

## Solution
If the option is enabled in project settings, display a snapshot of project health on the Directory project page.

## Todo
Any follow-up tasks that need to happen before or after the PR is merged.

## Notes for Reviewers
Anything that you want to tell the people who are going to review your pull request.

## Checklist
- [ ] Reasonable and adequate test coverage
- [ ] Requires a database migration
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`