### PR TITLE
Create reporter autoresponder

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -10,6 +10,12 @@
   height: 4rem;
 }
 
+pre {
+  background-color: #1d424a;
+  padding: 1em;
+  white-space: normal;
+}
+
 .guide-image {
   width: 70%;
   margin-left: auto;

--- a/app/controllers/autoresponders_controller.rb
+++ b/app/controllers/autoresponders_controller.rb
@@ -1,0 +1,101 @@
+class AutorespondersController < ApplicationController
+
+  before_action :authenticate_account!
+  before_action :scope_organization
+  before_action :scope_project
+  before_action :enforce_permissions
+  before_action :scope_autoresponder, only: [:edit, :show, :update]
+  before_action :scope_available_sources, only: [:new, :edit]
+
+  def new
+    if @project
+      @autoresponder = Autoresponder.new(project_id: @project.id)
+      org_autoresponder = @project.organization.present? ? "Organization Default" : nil
+    else
+      @autoresponder = Autoresponder.new(organization_id: @organization.id)
+    end
+    @available_sources = ["Beacon Default", org_autoresponder, @available_sources].flatten.compact - [@project&.name]
+  end
+
+  def show
+  end
+
+  def create
+    if @project
+      @template = Autoresponder.new(respondent_template_params.merge(project_id: @project.id))
+    elsif @organization
+      @template = Autoresponder.new(respondent_template_params.merge(organization_id: @organization.id))
+    end
+    if @template.save
+      redirect_to project_path(@project) if @project
+      redirect_to organization_path(@organization) if @organization
+    else
+      flash[:error] = @template.errors.full_messages
+      render :new
+    end
+  end
+
+  def clone
+    if existing = @subject.respondent_template
+      existing.destroy
+    end
+    source = respondent_template_params[:respondent_template_default_source]
+    if source == "Beacon Default"
+      @template = @subject.create_respondent_template(text: RespondentTemplate.beacon_default.text)
+    elsif source == "Organization Default"
+      @template = @subject.create_respondent_template(text: @organization&.respondent_template&.text || @project.organization.respondent_template.text)
+    else
+      source = current_account.projects.find_by(name: source).respondent_template
+      @template = @subject.create_respondent_template(text: source.text)
+    end
+    flash[:notice] = "You have successfully updated the respondent template."
+    render :edit
+  end
+
+  def edit
+  end
+
+  def update
+    if @autoresponder.update_attributes(autoresponder_params)
+      redirect_to @subject
+    else
+      flash[:error] = @autoresponder.errors.full_messages
+    end
+  end
+
+  private
+
+  def enforce_permissions
+    render_forbidden && return if @project && !current_account.can_manage_project_autoresponder?(@project)
+    render_forbidden && return if @organization && !current_account.can_manage_organization_autoresponder?(@organization)
+  end
+
+  def autoresponder_params
+    params.require(:autoresponder).permit(:text)
+  end
+
+  def scope_autoresponder
+    @autoresponder = @subject.autoresponder
+  end
+
+  def scope_available_sources
+    if @project&.organization
+      projects_with_autoresponder = @project.organization.projects.select(&:autoresponder?)
+    elsif @organization
+      projects_with_autoresponder = @organization.projects.select(&:autoresponder?)
+    end
+    projects_with_autoresponder ||= current_account.personal_projects.select(&:autoresponder?)
+    @available_sources = projects_with_autoresponder.map(&:name).flatten
+  end
+
+  def scope_organization
+    @organization = Organization.find_by(slug: params[:organization_slug])
+    @subject = @organization
+  end
+
+  def scope_project
+    @project = Project.find_by(slug: params[:project_slug])
+    @subject = @project
+  end
+
+end

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -141,6 +141,12 @@ class IssuesController < ApplicationController
       issue: @issue
     ).notify_of_new_issue.deliver_now
     NotificationService.notify_moderators_on_issue_via_sms(@project, @issue)
+    IssueNotificationsMailer.with(
+      email: current_account.email,
+      project: @project,
+      issue: @issue,
+      text: @project.autoresponder.populate_from(issue_url(@issue), project_url(@project))
+    ).autoresponder.deliver_now
   end
 
   def notify_on_status_change

--- a/app/mailers/issue_notifications_mailer.rb
+++ b/app/mailers/issue_notifications_mailer.rb
@@ -1,5 +1,13 @@
 class IssueNotificationsMailer < ApplicationMailer
 
+  def autoresponder
+    @project = params[:project]
+    @issue = params[:issue]
+    @email = params[:email]
+    @text = params[:text]
+    mail(to: @email, subject: "Beacon: #{@project.name} Issue ##{@issue.issue_number} has been opened")
+  end
+
   def notify_on_status_change
     @project = params[:project]
     @issue = params[:issue]

--- a/app/mailers/respondent_mailer.rb
+++ b/app/mailers/respondent_mailer.rb
@@ -3,13 +3,15 @@ class RespondentMailer < ApplicationMailer
   def notify_existing_account_of_issue
     @project_name = params[:project_name]
     @email = params[:email]
+    @text = params[:text]
+    @issue = params[:issue]
     mail(to: @email, subject: "Beacon: Your attention is needed on a code of conduct issue")
   end
 
   def notify_new_account_of_issue
     @project_name = params[:project_name]
     @email = params[:email]
-    @url = params[:url]
+    @text = params[:text]
     mail(to: @email, subject: "Beacon: Your attention is needed on a code of conduct issue")
   end
 

--- a/app/models/autoresponder.rb
+++ b/app/models/autoresponder.rb
@@ -1,0 +1,17 @@
+class Autoresponder < ApplicationRecord
+
+  belongs_to :project, optional: true
+  belongs_to :organization, optional: true
+
+  validates_presence_of :text
+
+  attr_accessor :default_source
+
+  def populate_from(issue_url, project_url)
+    text.gsub!("[[PROJECT_NAME]]", project.name)
+    text.gsub!("[[CODE_OF_CONDUCT_URL]]", project.coc_url)
+    text.gsub!("[[ISSUE_URL]]", issue_url)
+    text.gsub!("[[PROJECT_URL]]", project_url)
+    return text
+  end
+end

--- a/app/models/concerns/permissions.rb
+++ b/app/models/concerns/permissions.rb
@@ -57,6 +57,11 @@ module Permissions
     !!is_admin
   end
 
+  def can_manage_project_autoresponder?(project)
+    return false unless project.present?
+    project.moderator?(self)
+  end
+
   def can_manage_project_consequence_guide?(project)
     return false unless project.present?
     project.moderator?(self)
@@ -64,6 +69,11 @@ module Permissions
 
   def can_manage_project_respondent_template?(project)
     project.moderator?(self)
+  end
+
+  def can_manage_organization_autoresponder?(organization)
+    return false unless organization.present?
+    organization.owner?(self)
   end
 
   def can_manage_organization_consequence_guide?(organization)

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -4,6 +4,7 @@ class Organization < ApplicationRecord
   validates_presence_of :name
 
   belongs_to :account
+  has_one :autoresponder, dependent: :destroy
   has_one :consequence_guide, dependent: :destroy
   has_many :invitations, dependent: :destroy
   has_many :roles, dependent: :destroy
@@ -14,6 +15,10 @@ class Organization < ApplicationRecord
   after_create :create_consequence_guide
 
   attr_accessor :default_source
+
+  def autoresponder?
+    autoresponder.present?
+  end
 
   def consequence_guide?
     consequence_guide.consequences.any?
@@ -58,7 +63,7 @@ class Organization < ApplicationRecord
   end
 
   def setup_complete?
-    respondent_template && consequence_guide?
+    respondent_template && consequence_guide? && autoresponder?
   end
 
   def toggle_flagged

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -6,6 +6,7 @@ class Project < ApplicationRecord
 
   belongs_to :account
   belongs_to :organization, optional: true
+  has_one :autoresponder, dependent: :destroy
   has_one :project_setting, dependent: :destroy
   has_one :consequence_guide, dependent: :destroy
   has_one :respondent_template, dependent: :destroy
@@ -31,6 +32,10 @@ class Project < ApplicationRecord
 
   def all_moderators
     (moderators + organization_moderators + owners).uniq
+  end
+
+  def autoresponder?
+    autoresponder.present?
   end
 
   def confirmation_token
@@ -105,6 +110,7 @@ class Project < ApplicationRecord
     complete ||= false unless ownership_confirmed?
     complete ||= false unless respondent_template?
     complete ||= false unless coc_url.present?
+    complete ||= false unless autoresponder?
     complete = complete.nil? ? true : false
     update_attribute(:setup_complete, complete) unless setup_complete == complete
     return complete

--- a/app/models/respondent_template.rb
+++ b/app/models/respondent_template.rb
@@ -16,9 +16,9 @@ class RespondentTemplate < ApplicationRecord
     text.gsub!("[[CODE_OF_CONDUCT_URL]]", project.coc_url)
     text.gsub!("[[ISSUE_URL]]", issue_url)
 
-    if issue.consequence
-      text.gsub!("[[VIOLATION_EXAMPLE]]", severity.example)
-      text.gsub!("[[CONSEQUENCE]]", severity.consequence)
+    if consequence = issue.consequence
+      text.gsub!("[[VIOLATION_EXAMPLE]]", consequence.action)
+      text.gsub!("[[CONSEQUENCE]]", consequence.consequence)
     end
 
     return text

--- a/app/views/autoresponders/edit.html.erb
+++ b/app/views/autoresponders/edit.html.erb
@@ -1,0 +1,51 @@
+<% title "#{@subject.name}: Reporter Autoresponder" %>
+
+<h1><%= link_to @subject.name, @subject %>: Reporter Autoresponder</h1>
+
+<p>This is the email that will be automatically sent when a reporter opens a new issue.</p>
+
+<div class="row">
+
+  <div class="col">
+    <% url = project_autoresponder_path(@project) if @project.present? %>
+    <% url = organization_autoresponder_path(@organization) if @organization.present? %>
+    <%= form_for @autoresponder, url: url do |f| %>
+      <div class="form-group">
+        <%= f.text_area :text, class: "form-control", rows: 20 %>
+      </div>
+      <div class="actions">
+        <%= f.submit "Save", class: "btn btn-primary" %>
+        <%= link_to "Cancel", @subject, class: "btn btn-primary" %>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="col">
+    <h2>Cloning an Autoresponder</h2>
+    <p>You can customize your autoresponder from Beacon defaults or another one of your projects, or create your own.</p>
+
+    <% url = project_clone_autoresponder_path(@project) if @project.present? %>
+    <% url = organization_clone_autoresponder_path(@organization) if @organization.present? %>
+    <%= form_for @autoresponder, url: url do |f| %>
+      <div class="form-group col-sm-6">
+        <%= f.label :clone_from %>
+        <%= f.select :default_source, @available_sources, class: "form-control", include_blank: "Select..." %>
+      </div>
+
+      <div class="actions mb-3">
+        <%= f.submit "Clone", class: "btn btn-primary" %>
+      </div>
+    <% end %>
+
+    <h2>Tags</h2>
+    <p>The following tags will be auto-populated in the email that the reporter receives:</p>
+
+    <ul>
+      <li>[[PROJECT_NAME]]</li>
+      <li>[[CODE_OF_CONDUCT_URL]]</li>
+      <li>[[PROJECT_URL]]</li>
+      <li>[[ISSUE_URL]]</li>
+    </ul>
+
+  </div>
+</div>

--- a/app/views/autoresponders/new.html.erb
+++ b/app/views/autoresponders/new.html.erb
@@ -1,0 +1,50 @@
+<% title "#{@subject.name}: Reporter Autoresponder" %>
+
+<h1><%= link_to @subject.name, @subject %>: Reporter Autoresponder</h1>
+
+<p>This is the email that will be automatically sent when a reporter opens a new issue.</p>
+
+<div class="row">
+
+  <div class="col">
+    <% url = project_autoresponder_path(@project) if @project.present? %>
+    <% url = organization_autoresponder_path(@organization) if @organization.present? %>
+    <%= form_for @autoresponder, url: url do |f| %>
+      <div class="form-group">
+        <%= f.text_area :text, class: "form-control", rows: 20 %>
+      </div>
+      <div class="actions">
+        <%= f.submit "Save", class: "btn btn-primary" %>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="col">
+    <h2>Cloning an Autoresponder</h2>
+    <p>You can customize your autoresponder from Beacon defaults or another one of your projects, or create your own.</p>
+
+    <% url = project_clone_autoresponder_path(@project) if @project.present? %>
+    <% url = organization_clone_autoresponder_path(@organization) if @organization.present? %>
+    <%= form_for @autoresponder, url: url do |f| %>
+      <div class="form-group col-sm-6">
+        <%= f.label :clone_from %>
+        <%= f.select :default_source, @available_sources, class: "form-control", include_blank: "Select..." %>
+      </div>
+
+      <div class="actions mb-3">
+        <%= f.submit "Clone", class: "btn btn-primary" %>
+      </div>
+    <% end %>
+
+    <h2>Tags</h2>
+    <p>The following tags will be auto-populated in the email that the reporter receives:</p>
+
+    <ul>
+      <li>[[PROJECT_NAME]]</li>
+      <li>[[CODE_OF_CONDUCT_URL]]</li>
+      <li>[[PROJECT_URL]]</li>
+      <li>[[ISSUE_URL]]</li>
+    </ul>
+
+  </div>
+</div>

--- a/app/views/autoresponders/show.html.erb
+++ b/app/views/autoresponders/show.html.erb
@@ -1,0 +1,33 @@
+<% title "#{@subject.name}: Reporter Autoresponder" %>
+
+<h1><%= link_to @subject.name, @subject %>: Reporter Autoresponder</h1>
+
+<div class="row">
+
+  <div class="col">
+    <p>This is the email that will be automatically sent when a reporter opens a new issue.</p>
+
+    <textarea disabled="disabled" style="width: 100%" rows="30">
+      <%= @autoresponder.text %>
+    </textarea>
+
+    <% if @project && current_account.can_manage_project_autoresponder?(@project) %>
+      <%= link_to "Edit", edit_project_autoresponder_path(@project), class: "btn btn-primary" %>
+    <% elsif @organization && current_account.can_manage_organization_autoresponder?(@organization) %>
+      <%= link_to "Edit", edit_organization_autoresponder_path(@organization), class: "btn btn-primary" %>
+    <% end %>
+  </div>
+
+  <div class="col">
+    <h2>Tags</h2>
+    <p>The following tags will be auto-populated in the email that the reporter receives:</p>
+
+    <ul>
+      <li>[[PROJECT_NAME]]</li>
+      <li>[[CODE_OF_CONDUCT_URL]]</li>
+      <li>[[PROJECT_URL]]</li>
+      <li>[[ISSUE_URL]]</li>
+    </ul>
+
+  </div>
+</div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -40,7 +40,7 @@
       <% end %>
 
       <div class="form-group">
-        <label for="account_password">New Password (<%= @minimum_password_length %> characters minimum)</label><br />
+        <label for="account_password">New Password (<%= @minimum_password_length %> characters minimumgit )</label><br />
         <%= f.password_field :password, autocomplete: "new-password", class: "form-control" %>
       </div>
 

--- a/app/views/issue_notifications_mailer/autoresponder.html.inky
+++ b/app/views/issue_notifications_mailer/autoresponder.html.inky
@@ -1,0 +1,19 @@
+<% content_for :title do %>
+  Code of Conduct Issue Confirmation
+<% end %>
+
+<container style="margin-top: 2em;">
+  <row>
+    <columns>
+      <p>
+        <%= @text %>
+      </p>
+    </columns>
+  </row>
+
+  <row>
+    <columns>
+      <button href="<%= project_issue_url(@project, @issue) %>">View Issue</button>
+    </columns>
+  </row>
+</container>

--- a/app/views/issue_notifications_mailer/autoresponder.txt.erb
+++ b/app/views/issue_notifications_mailer/autoresponder.txt.erb
@@ -1,0 +1,3 @@
+<%= @text %>
+
+To view the issue, visit <%= project_issue_url(@project, @issue) %>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -38,6 +38,24 @@
               <% end %>
             </li>
             <li>
+              <% if @organization.autoresponder? %>
+                <%= link_to "Autoresponder", organization_autoresponder_path(@organization, @organization.autoresponder) %>
+              <% else %>
+                <%= link_to "Autoresponder", new_organization_autoresponder_path(@organization) %>
+              <% end %>
+              <% if !@organization.setup_complete? %>
+                <% if @organization.autoresponder? %>
+                  <span class="badge badge-pill badge-success">
+                    √
+                  </span>
+                <% else %>
+                  <span class="badge badge-pill badge-danger">
+                    x
+                  </span>
+                <% end %>
+              <% end %>
+            </li>
+            <li>
               <% if @organization.respondent_template %>
                 <%= link_to "Respondent Template", edit_organization_respondent_template_path(@organization, @organization.respondent_template) %>
                 <% if !@organization.setup_complete? %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -100,6 +100,24 @@
                 <% end %>
               </li>
               <li>
+                <% if @project.autoresponder? %>
+                  <%= link_to "Autoresponder", project_autoresponder_path(@project, @project.autoresponder) %>
+                <% else %>
+                  <%= link_to "Autoresponder", new_project_autoresponder_path(@project) %>
+                <% end %>
+                <% if !@project.setup_complete? %>
+                  <% if @project.autoresponder? %>
+                    <span class="badge badge-pill badge-success">
+                      √
+                    </span>
+                  <% else %>
+                    <span class="badge badge-pill badge-danger">
+                      x
+                    </span>
+                  <% end %>
+                <% end %>
+              </li>
+              <li>
                 <%= link_to "Impact and Consequences", project_consequence_guide_path(@project, @project.consequence_guide) %>
                 <% if @project.consequence_guide? %>
                   <span class="badge badge-pill badge-success">
@@ -192,6 +210,11 @@
             <% if @project.check_setup_complete? && current_account.can_manage_project?(@project) %>
               <li>
                 <%= link_to "Project Settings", project_settings_path(@project)  %>
+              </li>
+            <% end %>
+            <% if @project.autoresponder? %>
+              <li>
+                <%= link_to "Autoresponder", project_autoresponder_path(@project, @project.autoresponder) %>
               </li>
             <% end %>
             <% if @project.consequence_guide? %>

--- a/app/views/respondent_mailer/notify_existing_account_of_issue.html.inky
+++ b/app/views/respondent_mailer/notify_existing_account_of_issue.html.inky
@@ -5,18 +5,13 @@
 <container style="margin-top: 2em;">
   <row>
     <columns>
-      <p>
-        A code of conduct issue has been filed in the <%= @project_name %> project and you have been identified as the respondent.
-      </p>
-      <p>
-        To view the issue and respond, please sign in to Beacon and click on 'My Issues' in the navigation bar.
-      </p>
+      <p><%= @text.gsub(/\n\n/, "</p><p>") %></p>
     </columns>
   </row>
 
   <row>
     <columns>
-      <button href="<%= new_account_session_url %>">Sign In to Beacon</button>
+      <button href="<%= issue_url(@issue) %>">View Issue on Beacon</button>
     </columns>
   </row>
 </container>

--- a/app/views/respondent_mailer/notify_existing_account_of_issue.txt.erb
+++ b/app/views/respondent_mailer/notify_existing_account_of_issue.txt.erb
@@ -1,7 +1,6 @@
-Code of Conduct Enforcement Issue
+Code of Conduct Enforcement Issue on <%= @project_name %>
 
-A code of conduct issue has been filed in the <%= @project_name %> project and you
-have been identified as the respondent.
+<%= @text %>
 
 To view the issue and respond, please sign in to Beacon and click on 'My Issues' in the navigation bar.
 

--- a/app/views/respondent_mailer/notify_new_account_of_issue.html.inky
+++ b/app/views/respondent_mailer/notify_new_account_of_issue.html.inky
@@ -5,12 +5,7 @@
 <container style="margin-top: 2em;">
   <row>
     <columns>
-      <p>
-        A code of conduct issue has been filed in the <%= @project_name %> project and you have been identified as the respondent.
-      </p>
-      <p>
-        To view the issue and respond, please create an account on Beacon: <%= @url %>
-      </p>
+      <p><%= @text.gsub(/\n\n/, "</p><p>") %></p>
     </columns>
   </row>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
   resources :issues
 
   resources :organizations, param: :slug do
+    resource :autoresponder, only: [:new, :create, :edit, :show]
     resources :invitations, only: [:create]
     resources :respondent_templates, only: [:new, :create, :edit, :update, :show]
     resources :consequence_guides do
@@ -38,12 +39,14 @@ Rails.application.routes.draw do
     get "github_auth_token", to: "organizations#github_auth_token"
     post "import_projects_from_github", to: "organizations#import_projects_from_github"
     post "remove_moderator", to: "organizations#remove_moderator"
+    post "clone_autoresponder", to: "autoresponders#clone"
     post "clone_respondent_template", to: "respondent_templates#clone"
     patch "clone_respondent_template", to: "respondent_templates#clone"
   end
 
   resources :projects, param: :slug do
     resources :account_project_blocks
+    resource :autoresponder, only: [:new, :create, :edit, :show]
     resources :consequence_guides do
       resources :consequences
       patch "clone", to: "consequence_guides#clone"
@@ -66,6 +69,7 @@ Rails.application.routes.draw do
     get "settings", to: "project_settings#edit"
     get "moderators", to: "projects#moderators"
     get "ownership", to: "projects#ownership"
+    post "clone_autoresponder", to: "autoresponders#clone"
     post "clone_respondent_template", to: "respondent_templates#clone"
     post "remove_moderator", to: "projects#remove_moderator"
     patch "clone_respondent_template", to: "respondent_templates#clone"

--- a/db/migrate/20190324200806_create_reporter_autoresponder.rb
+++ b/db/migrate/20190324200806_create_reporter_autoresponder.rb
@@ -1,0 +1,11 @@
+class CreateReporterAutoresponder < ActiveRecord::Migration[5.2]
+  def change
+    create_table :autoresponders, id: :uuid do |t|
+      t.references :project, type: :uuid, foreign_key: true
+      t.references :organization, type: :uuid, foreign_key: true
+      t.string :scope
+      t.text :text
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_23_000310) do
+ActiveRecord::Schema.define(version: 2019_03_24_200806) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -129,6 +129,17 @@ ActiveRecord::Schema.define(version: 2019_03_23_000310) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["account_id"], name: "index_activity_logs_on_account_id"
+  end
+
+  create_table "autoresponders", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "project_id"
+    t.uuid "organization_id"
+    t.string "scope"
+    t.text "text"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["organization_id"], name: "index_autoresponders_on_organization_id"
+    t.index ["project_id"], name: "index_autoresponders_on_project_id"
   end
 
   create_table "consequence_guides", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -369,6 +380,8 @@ ActiveRecord::Schema.define(version: 2019_03_23_000310) do
   add_foreign_key "account_project_blocks", "projects"
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "activity_logs", "accounts"
+  add_foreign_key "autoresponders", "organizations"
+  add_foreign_key "autoresponders", "projects"
   add_foreign_key "consequence_guides", "organizations"
   add_foreign_key "consequence_guides", "projects"
   add_foreign_key "consequences", "consequence_guides"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -174,7 +174,6 @@ ActiveRecord::Schema.define(version: 2019_03_24_200806) do
     t.string "uid"
     t.string "email"
     t.uuid "account_id"
-    t.string "oauth_token"
     t.string "token_encrypted"
     t.index ["account_id"], name: "index_credentials_on_account_id"
     t.index ["provider", "uid"], name: "index_credentials_on_provider_and_uid", unique: true
@@ -259,14 +258,11 @@ ActiveRecord::Schema.define(version: 2019_03_24_200806) do
     t.string "slug"
     t.text "description"
     t.uuid "account_id"
-    t.datetime "flagged_at"
-    t.text "flagged_reason"
-    t.datetime "confirmed_at"
-    t.string "confirmation_token_url"
     t.string "remote_org_name"
-    t.datetime "created_at", default: "2019-03-16 00:00:00"
-    t.datetime "updated_at", default: "2019-03-16 00:00:00"
+    t.datetime "created_at", default: "2019-03-24 00:00:00"
+    t.datetime "updated_at", default: "2019-03-24 00:00:00"
     t.boolean "is_flagged", default: false
+    t.text "flagged_reason"
     t.index ["account_id"], name: "index_organizations_on_account_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,36 @@
+Autoresponder.create(
+  scope: "template",
+  text: %{
+Thank you for opening a code of conduct issue for [[PROJECT_NAME]].
+
+We take code of conduct violations very seriously. We commit to you that we will
+fully investigate the issue, with fairness and the health of our community at the
+forefront.
+
+One of our moderators will acknowledge your issue within 24 hours. You will receive
+an email notification when this occurs. At this point, our investigation will begin.
+You can message the moderators with additional details using the contact form at the
+bottom of the issue page. You can also attach additional screenshots as needed.
+Moderators can respond to your messages, and you will also receive a notification
+when this occurs.
+
+For your safety and security, the respondent (the person named in your issue)
+will not be able to see the issue description that you have provided, nor any
+subsequence communication between you and the moderators. The respondent will also
+not be given any identifying information about you.
+
+You can reference the Community Impact and Consequences guide on our
+project page at [[PROJECT_PAGE]] for more information. You can also see our code of
+conduct at [[CODE_OF_CONDUCT_URL]].
+
+Thank you again, and please feel free to reach out should you have any questions
+about this issue or our enforcement policies.
+
+The issue URL for your reference is [[ISSUE_URL]].
+
+  }
+)
+
 template = ConsequenceGuide.find_or_create_by(scope: "template")
 template.consequences.destroy_all
 

--- a/lib/tasks/defaults.rake
+++ b/lib/tasks/defaults.rake
@@ -17,10 +17,42 @@ To respond to this issue, please visit [[ISSUE_URL]]. You may be prompted to cre
 Thank you in advance for your prompt attention. As moderators, we promise a fair and timely evaluation of this situation, and will do everything in our power to address this issue in a way that is respectful of both you and our shared community.
     }
 
-    RespondentTemplate.create(
-      is_beacon_default: true,
-      text: text
-    )
+  end
+
+  desc 'Create default autoresponder'
+  task :autoresponder => :environment do
+    autoresponder = Autoresponder.find_or_create_by(scope: "template")
+    autoresponder.text = %{
+Thank you for opening a code of conduct issue for [[PROJECT_NAME]].
+
+We take code of conduct violations very seriously. We commit to you that we will fully investigate the issue, with fairness and the health of our community at the forefront.
+
+One of our moderators will acknowledge your issue within 24 hours. You will receive an email notification when this occurs. At this point, our investigation will begin. You can message the moderators with additional details using the contact form at the bottom of the issue page. You can also attach additional screenshots as needed. Moderators can respond to your messages, and you will also receive a notification when this occurs.
+
+For your safety and security, the respondent (the person named in your issue) will not be able to see the issue description that you have provided, nor any subsequence communication between you and the moderators. The respondent will also not be given any identifying information about you.
+
+You can reference the Community Impact and Consequences guide on our project page at [[PROJECT_URL]] for more information. You can also see our code of conduct at [[CODE_OF_CONDUCT_URL]].
+
+Thank you again, and please feel free to reach out should you have any questions about this issue or our enforcement policies.
+    }
+    autoresponder.save
+  end
+
+  desc 'Apply default autoresponder to organizations and projects'
+  task :apply_default_autoresponder => :environment do
+    autoresponder = Autoresponder.find_by(scope: "template")
+    Organization.all.each do |organization|
+      Autoresponder.create(
+        organization_id: organization.id,
+        text: autoresponder.text
+      )
+    end
+    Project.all.each do |project|
+      Autoresponder.create(
+        project_id: project.id,
+        text: autoresponder.text
+      )
+    end
   end
 
 end

--- a/spec/controllers/issue_invitations_controller_spec.rb
+++ b/spec/controllers/issue_invitations_controller_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe IssueInvitationsController, type: :controller do
     let(:issue)       { Issue.new(id: SecureRandom.uuid, issue_number: 1) }
 
     before do
+      RespondentTemplate.create(project: project, text: "foo")
       allow_any_instance_of(ValidEmail2::Address).to receive(:valid_mx?) { true }
       allow(Project).to receive(:find_by).and_return(project)
       allow(Issue).to receive(:find).and_return(issue)

--- a/spec/controllers/issues_controller_spec.rb
+++ b/spec/controllers/issues_controller_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe IssuesController, type: :controller do
     before do
       allow_any_instance_of(ValidEmail2::Address).to receive(:valid_mx?) { true }
       allow_any_instance_of(Issue).to receive(:set_issue_number)
+      Autoresponder.create(project: project, text: "Foo")
       Role.create(account_id: moderator.id, project_id: project.id, is_owner: true)
     end
 

--- a/spec/features/reporter_spec.rb
+++ b/spec/features/reporter_spec.rb
@@ -12,6 +12,7 @@ describe "the reporting process", type: :feature do
     allow_any_instance_of(Accounts::RegistrationsController).to receive(:verify_recaptcha).and_return(true)
     allow_any_instance_of(IssuesController).to receive(:verify_recaptcha).and_return(true)
     Role.create(account_id: maintainer.id, project_id: project.id, is_owner: true)
+    Autoresponder.create(project: project, text: "Foo")
   end
 
   it "enables a reporter to sign in" do


### PR DESCRIPTION
We welcome contributions involving code, documentation, or design. If you'd like to contribute, please check out [our guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

Please refer to our [contributing guidelines](https://github.com/ContributorCovenant/beacon/blob/release/CONTRIBUTING.md) and follow the guidance in that document to improve the chances of your PR being merged.

## Problem
Moderators should be able to customize the email that gets sent to reporters when an issue is opened.

## Solution
Create a reporter autoresponder for organizations and projects.

## Todo
```
rake defaults:autoresponder
rake defaults:apply_default_autoresponder
```

## Notes for Reviewers
Anything that you want to tell the people who are going to review your pull request.

## Checklist
- [ ] Reasonable and adequate test coverage
- [x] Requires a database migration
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`