### PR TITLE
Add background jobs for sms notification

### DIFF
--- a/.env.development.sample
+++ b/.env.development.sample
@@ -17,4 +17,4 @@ GITLAB_APP_SECRET=
 
 
 ## Redis URL
-REDIS_URL=redis://redis:6379
+REDIS_URL=

--- a/.env.development.sample
+++ b/.env.development.sample
@@ -14,3 +14,7 @@ GITHUB_APP_SECRET=
 ## Gitlab Secrets
 GITLAB_APP_ID=
 GITLAB_APP_SECRET=
+
+
+## Redis URL
+REDIS_URL=redis://redis:6379

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,12 @@ script:
 - bundle exec brakeman
 services:
 - postgresql
+- redis-server
 addons:
   postgresql: '10'
   apt:
     packages:
     - postgresql-10
     - postgresql-client-10
+env:
+  - REDIS_URL=redis://localhost

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV BUNDLE_PATH=/bundle \
     BUNDLE_BIN=/bundle/bin \
     GEM_HOME=/bundle
 ENV PATH="${BUNDLE_BIN}:${PATH}"
-
+ENV REDIS_URL="redis://redis:6379"
 FROM dev AS ci
 COPY Gemfile Gemfile.lock ./
 RUN bundle install --jobs 20 --retry 5

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem "popper_js", "~> 1.14.5"
 gem 'premailer-rails'
 gem "puma", "~> 3.11"
 gem "recaptcha"
+gem "resque"
 gem "sass-rails", "~> 5.0"
 gem "sendgrid-ruby"
 gem "sentry-raven"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,6 +210,7 @@ GEM
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
+    mono_logger (1.1.0)
     msgpack (1.2.4)
     multi_json (1.13.1)
     multi_xml (0.6.0)
@@ -299,14 +300,23 @@ GEM
       ffi (~> 1.0)
     recaptcha (4.13.1)
       json
+    redis (4.1.0)
+    redis-namespace (1.6.0)
+      redis (>= 3.0.4)
     regexp_parser (1.3.0)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
       uber (< 0.2.0)
-    responders (2.4.1)
-      actionpack (>= 4.2.0, < 6.0)
-      railties (>= 4.2.0, < 6.0)
+    responders (2.4.0)
+      actionpack (>= 4.2.0, < 5.3)
+      railties (>= 4.2.0, < 5.3)
+    resque (2.0.0)
+      mono_logger (~> 1.0)
+      multi_json (~> 1.0)
+      redis-namespace (~> 1.6)
+      sinatra (>= 0.9.2)
+      vegas (~> 0.1.2)
     retriable (3.1.2)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
@@ -420,6 +430,8 @@ GEM
     valid_email2 (3.0.0)
       activemodel (>= 3.2)
       mail (~> 2.5)
+    vegas (0.1.11)
+      rack (>= 1.0.0)
     warden (1.2.8)
       rack (>= 2.0.6)
     web-console (3.7.0)
@@ -475,6 +487,7 @@ DEPENDENCIES
   rails-controller-testing
   rails_layout!
   recaptcha
+  resque
   rspec-rails
   rubocop (~> 0.62.0)
   sass-rails (~> 5.0)

--- a/app/controllers/issue_comments_controller.rb
+++ b/app/controllers/issue_comments_controller.rb
@@ -59,11 +59,11 @@ class IssueCommentsController < ApplicationController
     if @project.moderator?(current_account) && visible_to_reporter?
       email = @issue.reporter.email
       commenter_kind = "moderator"
-      NotificationService.notify(account_id: @issue.reporter.id, project_id: @project.id, issue_id: @issue.id, issue_comment_id: @comment.id)
+      Resque.enqueue(NotificationWorker, @issue.reporter.id,  @project.id, @issue.id, @comment.id)
     elsif @project.moderator?(current_account) && visible_to_respondent?
       email = @issue.respondent.email
       commenter_kind = "moderator"
-      NotificationService.notify(account_id: @issue.respondent.id, project_id: @project.id, issue_id: @issue.id, issue_comment_id: @comment.id)
+      Resque.enqueue(NotificationWorker, @issue.respondent.id,  @project.id, @issue.id, @comment.id)
     elsif @comment.commenter == @issue.reporter
       email = @project.moderator_emails
       commenter_kind = "reporter"
@@ -81,7 +81,7 @@ class IssueCommentsController < ApplicationController
       end
       @project.moderators.each do |moderator|
         next if moderator == current_account
-        NotificationService.notify(account_id: moderator.id, project_id: @project.id, issue_id: @issue.id, issue_comment_id: @comment.id)
+        Resque.enqueue(NotificationWorker, moderator.id,  @project.id, @issue.id, @comment.id)
       end
       if unnotified_moderators.any?
         IssueNotificationsMailer.with(

--- a/app/controllers/issue_comments_controller.rb
+++ b/app/controllers/issue_comments_controller.rb
@@ -59,11 +59,11 @@ class IssueCommentsController < ApplicationController
     if @project.moderator?(current_account) && visible_to_reporter?
       email = @issue.reporter.email
       commenter_kind = "moderator"
-      Resque.enqueue(NotificationWorker, @issue.reporter.id,  @project.id, @issue.id, @comment.id)
+      Resque.enqueue(NotificationWorker, @issue.reporter.id, @project.id, @issue.id, @comment.id)
     elsif @project.moderator?(current_account) && visible_to_respondent?
       email = @issue.respondent.email
       commenter_kind = "moderator"
-      Resque.enqueue(NotificationWorker, @issue.respondent.id,  @project.id, @issue.id, @comment.id)
+      Resque.enqueue(NotificationWorker, @issue.respondent.id, @project.id, @issue.id, @comment.id)
     elsif @comment.commenter == @issue.reporter
       email = @project.moderator_emails
       commenter_kind = "reporter"
@@ -81,7 +81,7 @@ class IssueCommentsController < ApplicationController
       end
       @project.moderators.each do |moderator|
         next if moderator == current_account
-        Resque.enqueue(NotificationWorker, moderator.id,  @project.id, @issue.id, @comment.id)
+        Resque.enqueue(NotificationWorker, moderator.id, @project.id, @issue.id, @comment.id)
       end
       if unnotified_moderators.any?
         IssueNotificationsMailer.with(

--- a/app/controllers/issue_comments_controller.rb
+++ b/app/controllers/issue_comments_controller.rb
@@ -59,11 +59,11 @@ class IssueCommentsController < ApplicationController
     if @project.moderator?(current_account) && visible_to_reporter?
       email = @issue.reporter.email
       commenter_kind = "moderator"
-      NotificationService.notify(account: @issue.reporter, project: @project, issue_id: @issue.id, issue_comment_id: @comment.id)
+      NotificationService.notify(account_id: @issue.reporter.id, project_id: @project.id, issue_id: @issue.id, issue_comment_id: @comment.id)
     elsif @project.moderator?(current_account) && visible_to_respondent?
       email = @issue.respondent.email
       commenter_kind = "moderator"
-      NotificationService.notify(account: @issue.respondent, project: @project, issue_id: @issue.id, issue_comment_id: @comment.id)
+      NotificationService.notify(account_id: @issue.respondent.id, project_id: @project.id, issue_id: @issue.id, issue_comment_id: @comment.id)
     elsif @comment.commenter == @issue.reporter
       email = @project.moderator_emails
       commenter_kind = "reporter"
@@ -81,7 +81,7 @@ class IssueCommentsController < ApplicationController
       end
       @project.moderators.each do |moderator|
         next if moderator == current_account
-        NotificationService.notify(account: moderator, project: @project, issue_id: @issue.id, issue_comment_id: @comment.id)
+        NotificationService.notify(account_id: moderator.id, project_id: @project.id, issue_id: @issue.id, issue_comment_id: @comment.id)
       end
       if unnotified_moderators.any?
         IssueNotificationsMailer.with(

--- a/app/controllers/issue_comments_controller.rb
+++ b/app/controllers/issue_comments_controller.rb
@@ -59,11 +59,18 @@ class IssueCommentsController < ApplicationController
     if @project.moderator?(current_account) && visible_to_reporter?
       email = @issue.reporter.email
       commenter_kind = "moderator"
-      Resque.enqueue(NotificationWorker, @issue.reporter.id, @project.id, @issue.id, @comment.id)
+      NotificationService.enqueu_notification(account_id: @issue.reporter.id,
+                                              project_id: @project.id,
+                                              issue_id: @issue.id,
+                                              issue_comment_id: @comment.id)
     elsif @project.moderator?(current_account) && visible_to_respondent?
       email = @issue.respondent.email
       commenter_kind = "moderator"
-      Resque.enqueue(NotificationWorker, @issue.respondent.id, @project.id, @issue.id, @comment.id)
+      NotificationService.enqueu_notification(account_id: @issue.respondent.id,
+                                              project_id: @project.id,
+                                              issue_id: @issue.id,
+                                              issue_comment_id: @comment.id)
+
     elsif @comment.commenter == @issue.reporter
       email = @project.moderator_emails
       commenter_kind = "reporter"
@@ -81,7 +88,10 @@ class IssueCommentsController < ApplicationController
       end
       @project.moderators.each do |moderator|
         next if moderator == current_account
-        Resque.enqueue(NotificationWorker, moderator.id, @project.id, @issue.id, @comment.id)
+        NotificationService.enqueu_notification(account_id: moderator.id,
+                                                project_id: @project.id,
+                                                issue_id: @issue.id,
+                                                issue_comment_id: @comment.id)
       end
       if unnotified_moderators.any?
         IssueNotificationsMailer.with(

--- a/app/controllers/issue_invitations_controller.rb
+++ b/app/controllers/issue_invitations_controller.rb
@@ -25,7 +25,7 @@ class IssueInvitationsController < ApplicationController
         issue: @issue
       ).notify_existing_account_of_issue.deliver_now
       AccountIssue.create(issue_id: @issue.id, account: account)
-      NotificationService.notify(account: account, project: @project, issue_id: @issue.id)
+      NotificationService.notify(account_id: account.id, project_id: @project.id, issue_id: @issue.id)
       @issue.update_attribute(:respondent_encrypted_id, EncryptionService.encrypt(account.id))
     else
       IssueInvitation.create(

--- a/app/controllers/issue_invitations_controller.rb
+++ b/app/controllers/issue_invitations_controller.rb
@@ -25,7 +25,7 @@ class IssueInvitationsController < ApplicationController
         issue: @issue
       ).notify_existing_account_of_issue.deliver_now
       AccountIssue.create(issue_id: @issue.id, account: account)
-      Resque.enqueue(NotificationWorker, account.id,  @project.id, @issue.id)      
+      Resque.enqueue(NotificationWorker, account.id, @project.id, @issue.id)
       @issue.update_attribute(:respondent_encrypted_id, EncryptionService.encrypt(account.id))
     else
       IssueInvitation.create(

--- a/app/controllers/issue_invitations_controller.rb
+++ b/app/controllers/issue_invitations_controller.rb
@@ -25,7 +25,7 @@ class IssueInvitationsController < ApplicationController
         issue: @issue
       ).notify_existing_account_of_issue.deliver_now
       AccountIssue.create(issue_id: @issue.id, account: account)
-      NotificationService.notify(account_id: account.id, project_id: @project.id, issue_id: @issue.id)
+      Resque.enqueue(NotificationWorker, account.id,  @project.id, @issue.id)      
       @issue.update_attribute(:respondent_encrypted_id, EncryptionService.encrypt(account.id))
     else
       IssueInvitation.create(

--- a/app/controllers/issue_invitations_controller.rb
+++ b/app/controllers/issue_invitations_controller.rb
@@ -25,7 +25,9 @@ class IssueInvitationsController < ApplicationController
         issue: @issue
       ).notify_existing_account_of_issue.deliver_now
       AccountIssue.create(issue_id: @issue.id, account: account)
-      Resque.enqueue(NotificationWorker, account.id, @project.id, @issue.id)
+      NotificationService.notify(account_id: account.id,
+                                 project_id: @project.id,
+                                 issue_id: @issue.id)
       @issue.update_attribute(:respondent_encrypted_id, EncryptionService.encrypt(account.id))
     else
       IssueInvitation.create(

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -139,7 +139,7 @@ class IssuesController < ApplicationController
 
   def notify_on_new_issue
     @project.moderators.each do |moderator|
-      Resque.enqueue(NotificationWorker, moderator.id,  @project.id, @issue.id)
+      Resque.enqueue(NotificationWorker, moderator.id, @project.id, @issue.id)
     end
     IssueNotificationsMailer.with(
       email: @project.moderator_emails,

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -139,7 +139,9 @@ class IssuesController < ApplicationController
 
   def notify_on_new_issue
     @project.moderators.each do |moderator|
-      Resque.enqueue(NotificationWorker, moderator.id, @project.id, @issue.id)
+      NotificationService.notify(account_id: moderator.id,
+                                 project_id: @project.id,
+                                 issue_id: @issue.id)
     end
     IssueNotificationsMailer.with(
       email: @project.moderator_emails,

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -139,7 +139,7 @@ class IssuesController < ApplicationController
 
   def notify_on_new_issue
     @project.moderators.each do |moderator|
-      NotificationService.notify(account_id: moderator.id, project_id: @project.id, issue_id: @issue.id)
+      Resque.enqueue(NotificationWorker, moderator.id,  @project.id, @issue.id)
     end
     IssueNotificationsMailer.with(
       email: @project.moderator_emails,

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -139,7 +139,7 @@ class IssuesController < ApplicationController
 
   def notify_on_new_issue
     @project.moderators.each do |moderator|
-      NotificationService.notify(account: moderator, project: @project, issue_id: @issue.id)
+      NotificationService.notify(account_id: moderator.id, project_id: @project.id, issue_id: @issue.id)
     end
     IssueNotificationsMailer.with(
       email: @project.moderator_emails,

--- a/app/jobs/notification_worker.rb
+++ b/app/jobs/notification_worker.rb
@@ -1,5 +1,5 @@
 class NotificationWorker
-  @queue = :notification
+  @queue = :sms_notifications
 
   def self.perform(account_id, project_id, issue_id, issue_comment_id)
     NotificationService.notify(account_id: account_id,

--- a/app/jobs/notification_worker.rb
+++ b/app/jobs/notification_worker.rb
@@ -1,0 +1,11 @@
+class NotificationWorker
+  @queue = :notification
+
+  def self.perform(account_id, project_id, issue_id, issue_comment_id)
+    NotificationService.notify(account_id: account_id,
+                               project_id: project_id,
+                               issue_id: issue_id,
+                               issue_comment_id: issue_comment_id)
+  end
+
+end

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -1,6 +1,14 @@
 class NotificationService
 
-  def self.notify(account:, project:, issue_id:, issue_comment_id: nil)
+  def self.notify(account_id:, project_id:, issue_id:, issue_comment_id: nil)
+
+    project = Project.find(project_id)
+    account = Account.find(account_id)
+
+    self.do_notify(account, project, issue_id, issue_comment_id)
+  end
+
+  def self.do_notify(account, project, issue_id, issue_comment_id)
     notification = Notification.create(
       project_id: project.id,
       issue_id: issue_id,

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -1,13 +1,13 @@
 class NotificationService
 
+  def self.enqueu_notification(account_id:, project_id:, issue_id:, issue_comment_id: nil)
+    Resque.enqueue(NotificationWorker, account_id, project_id, issue_id, issue_comment_id)
+  end
+
   def self.notify(account_id:, project_id:, issue_id:, issue_comment_id: nil)
     project = Project.find(project_id)
     account = Account.find(account_id)
 
-    self.do_notify(account, project, issue_id, issue_comment_id)
-  end
-
-  def self.do_notify(account, project, issue_id, issue_comment_id)
     notification = Notification.create(
       project_id: project.id,
       issue_id: issue_id,

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -1,7 +1,6 @@
 class NotificationService
 
   def self.notify(account_id:, project_id:, issue_id:, issue_comment_id: nil)
-
     project = Project.find(project_id)
     account = Account.find(account_id)
 

--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -1,0 +1,6 @@
+rails_root = ENV['RAILS_ROOT'] || File.dirname(__FILE__) + '/../..'
+rails_env = ENV['RAILS_ENV'] || 'development'
+config_file = rails_root + '/config/resque.yml'
+
+resque_config = YAML::load(ERB.new(IO.read(config_file)).result)
+Resque.redis = resque_config[rails_env]

--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -2,5 +2,5 @@ rails_root = ENV['RAILS_ROOT'] || File.dirname(__FILE__) + '/../..'
 rails_env = ENV['RAILS_ENV'] || 'development'
 config_file = rails_root + '/config/resque.yml'
 
-resque_config = YAML::load(ERB.new(IO.read(config_file)).result)
+resque_config = YAML.safe_load(ERB.new(IO.read(config_file)).result)
 Resque.redis = resque_config[rails_env]

--- a/config/resque.yml
+++ b/config/resque.yml
@@ -1,0 +1,5 @@
+development: redis://redis:6379
+test: redis://redis:6379
+staging: <%= ENV['REDIS_URL'] %>
+fi: redis://redis:6379
+production: <%= ENV['REDIS_URL'] %>

--- a/config/resque.yml
+++ b/config/resque.yml
@@ -1,5 +1,5 @@
-development: redis://redis:6379
-test: redis://redis:6379
+development: <%= ENV['REDIS_URL'] %>
+test: <%= ENV['REDIS_URL'] %>
 staging: <%= ENV['REDIS_URL'] %>
-fi: redis://redis:6379
+fi: <%= ENV['REDIS_URL'] %>
 production: <%= ENV['REDIS_URL'] %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,5 @@
 require 'resque/server'
 
-
 Rails.application.routes.draw do
   devise_for :accounts, controllers: {
     registrations: "accounts/registrations",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,10 @@ Rails.application.routes.draw do
     authy_onetouch_status: "/onetouch-status"
   }
 
-  mount Resque::Server.new, at: "/resque"
+  # Resque background jobs
+  authenticate :account, ->(u) { u.is_admin? } do
+    mount Resque::Server.new, at: "/resque"
+  end
 
   root to: "static_content#main"
   get "about", to: "static_content#about"
@@ -84,6 +87,7 @@ Rails.application.routes.draw do
   end
 
   namespace :admin do
+
     resources :abuse_reports do
       post "dismiss", to: "abuse_reports#dismiss"
       post "resolve", to: "abuse_reports#resolve"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,6 @@
+require 'resque/server'
+
+
 Rails.application.routes.draw do
   devise_for :accounts, controllers: {
     registrations: "accounts/registrations",
@@ -8,6 +11,8 @@ Rails.application.routes.draw do
     verify_authy_installation: "/verify-installation",
     authy_onetouch_status: "/onetouch-status"
   }
+
+  mount Resque::Server.new, at: "/resque"
 
   root to: "static_content#main"
   get "about", to: "static_content#about"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,9 +16,27 @@ services:
       - "3000:3000"
     depends_on:
       - db
+      - redis
   db:
     image: "postgres:11.1"
     environment:
       POSTGRES_PASSWORD: postgres
+  redis:
+    image: redis
+    ports:
+      - 6379:6379
+    volumes:
+      - redis:/data
+  resque:
+    build:
+      context: .
+    command: bundle exec rake resque:work QUEUE='*'
+    volumes:
+      - .:/myapp
+      - bundle:/bundle
+    depends_on:
+      - db
+      - redis
 volumes:
-  bundle:
+  bundle: {}
+  redis: {}

--- a/lib/tasks/resque.rake
+++ b/lib/tasks/resque.rake
@@ -1,0 +1,2 @@
+require 'resque/tasks'
+task 'resque:setup' => :environment

--- a/spec/controllers/issues_controller_spec.rb
+++ b/spec/controllers/issues_controller_spec.rb
@@ -55,8 +55,8 @@ RSpec.describe IssuesController, type: :controller do
           issue: { description: "My CoC issue description" }
         }
         expect(NotificationService).to have_received(:notify).with(
-          account: moderator,
-          project: project,
+          account_id: moderator.id,
+          project_id: project.id,
           issue_id: Issue.last.id
         )
       end

--- a/spec/controllers/issues_controller_spec.rb
+++ b/spec/controllers/issues_controller_spec.rb
@@ -50,15 +50,17 @@ RSpec.describe IssuesController, type: :controller do
 
       it "notifies project moderators" do
         controller.sign_in(reporter, scope: :account)
-        post :create, params: {
-          project_slug: project.slug,
-          issue: { description: "My CoC issue description" }
-        }
-        expect(NotificationService).to have_received(:notify).with(
-          account_id: moderator.id,
-          project_id: project.id,
-          issue_id: Issue.last.id
-        )
+        Resque.inline do
+          post :create, params: {
+            project_slug: project.slug,
+            issue: { description: "My CoC issue description" }
+          }
+          expect(NotificationService).to have_received(:notify).with(
+            account_id: moderator.id,
+            project_id: project.id,
+            issue_id: Issue.last.id
+          )
+        end
       end
 
     end

--- a/spec/controllers/issues_controller_spec.rb
+++ b/spec/controllers/issues_controller_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe IssuesController, type: :controller do
       before do
         allow_any_instance_of(Project).to receive(:accepting_issues?).and_return(true)
         allow(NotificationService).to receive(:notify)
+        allow(Resque).to receive(:enqueue)
       end
 
       it "allows an issue to be opened" do
@@ -55,6 +56,13 @@ RSpec.describe IssuesController, type: :controller do
             project_slug: project.slug,
             issue: { description: "My CoC issue description" }
           }
+          expect(Resque).to have_received(:enqueue).with(
+            NotificationWorker,
+            moderator.id,
+            project.id,
+            issue_id,
+            nil
+          )
           expect(NotificationService).to have_received(:notify).with(
             account_id: moderator.id,
             project_id: project.id,

--- a/spec/features/bad_actor_spec.rb
+++ b/spec/features/bad_actor_spec.rb
@@ -169,14 +169,16 @@ describe "a reporter or respondent adding an issue comment" do
     end
 
     it "sends an email notification only once" do
-      login_as(reporter, scope: :account)
-      visit issue_path(issue, project_slug: project.slug)
-      fill_in "issue_comment_text", with: "Trigger a notification"
-      click_button "Send Message"
-      expect(ActionMailer::Base.deliveries.size).to eq(1)
-      fill_in "issue_comment_text", with: "Trigger a notification"
-      click_button "Send Message"
-      expect(ActionMailer::Base.deliveries.size).to eq(1)
+      Resque.inline do
+        login_as(reporter, scope: :account)
+        visit issue_path(issue, project_slug: project.slug)
+        fill_in "issue_comment_text", with: "Trigger a notification"
+        click_button "Send Message"
+        expect(ActionMailer::Base.deliveries.size).to eq(1)
+        fill_in "issue_comment_text", with: "Trigger a notification"
+        click_button "Send Message"
+        expect(ActionMailer::Base.deliveries.size).to eq(1)
+      end
     end
 
   end

--- a/spec/features/moderator_spec.rb
+++ b/spec/features/moderator_spec.rb
@@ -26,17 +26,18 @@ describe "moderation", type: :feature do
 
     before do
       NotificationService.notify(
-        account: moderator,
-        project: project,
+        account_id: moderator.id,
+        project_id: project.id,
         issue_id: issue.id,
         issue_comment_id: nil
       )
       NotificationService.notify(
-        account: moderator,
-        project: project,
+        account_id: moderator.id,
+        project_id: project.id,
         issue_id: issue.id,
         issue_comment_id: issue_comment.id
       )
+      moderator.reload
     end
 
     it "indicates in the main navigation that there is a new issue in a project" do

--- a/spec/features/respondent_spec.rb
+++ b/spec/features/respondent_spec.rb
@@ -32,11 +32,12 @@ describe "the respondent experience", type: :feature do
 
       before do
         NotificationService.notify(
-          account: respondent,
-          project: project,
+          account_id: respondent.id,
+          project_id: project.id,
           issue_id: issue.id,
           issue_comment_id: nil
         )
+        respondent.reload
       end
 
       it "indicates in the main navigation that there is an issue" do
@@ -59,11 +60,12 @@ describe "the respondent experience", type: :feature do
 
       before do
         NotificationService.notify(
-          account: respondent,
-          project: project,
+          account_id: respondent.id,
+          project_id: project.id,
           issue_id: issue.id,
           issue_comment_id: issue_comment.id
         )
+        respondent.reload
       end
 
       it "indicates in the main navigation that there is a new message" do

--- a/spec/services/notification_service_spec.rb
+++ b/spec/services/notification_service_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe NotificationService do
   describe "#notify" do
 
     it "creates a notification" do
-      NotificationService.notify(account: account, project: project, issue_id: issue_1.id)
-      expect(account.notifications.size).to eq(1)
+      NotificationService.notify(account_id: account.id, project_id: project.id, issue_id: issue_1.id)
+      expect(account.reload.notifications.size).to eq(1)
     end
 
   end
@@ -24,10 +24,10 @@ RSpec.describe NotificationService do
   describe "#notified!" do
 
     it "destroys a notification" do
-      NotificationService.notify(account: account, project: project, issue_id: issue_1.id)
-      NotificationService.notify(account: account, project: project, issue_id: issue_2.id)
-      NotificationService.notify(account: account, project: project, issue_id: issue_3.id)
-      NotificationService.notified!(account: account, issue_id: issue_1.id)
+      NotificationService.notify(account_id: account.id, project_id: project.id, issue_id: issue_1.id)
+      NotificationService.notify(account_id: account.id, project_id: project.id, issue_id: issue_2.id)
+      NotificationService.notify(account_id: account.id, project_id: project.id, issue_id: issue_3.id)
+      NotificationService.notified!(account: account.reload, issue_id: issue_1.id)
       account_reloaded = Account.find_by(email: account.email)
       expect(account_reloaded.notifications.size).to eq(2)
     end


### PR DESCRIPTION
We welcome contributions involving code, documentation, or design. If you'd like to contribute, please check out [our guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

Please refer to our [contributing guidelines](https://github.com/ContributorCovenant/beacon/blob/release/CONTRIBUTING.md) and follow the guidance in that document to improve the chances of your PR being merged.

## Problem
[Move sending sms notification to background jobs](https://github.com/ContributorCovenant/beacon/issues/117)
## Solution
Pretty straightforward implementation using [`Resque`](https://github.com/resque/resque) and `redis` server.
Jobs are added to a queue named `notifications` and enqueued.

## Todo
### Requirements:
 - Redis Server need to be setup on production.
 - `ENV[REDIS_URL]` must be added to `.env` file

### Setup
The following `rake` task must be executed on the production server too
```
bundle exec rake resque:work QUEUE='*'
```

## Notes for Reviewers
 - Do we need send notification in a chronical order ? Currently notifications are being sent asynchronously.

## Checklist
- [ ] Reasonable and adequate test coverage
- [ ] Requires a database migration
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`
