### PR TITLE
Add sort key to projects

### DIFF
--- a/app/controllers/directory_controller.rb
+++ b/app/controllers/directory_controller.rb
@@ -3,7 +3,7 @@ class DirectoryController < ApplicationController
   breadcrumb "Directory", :directory_path
 
   def index
-    @page_index = Project.for_directory.pluck(:name).map(&:first).uniq
+    @page_index = Project.for_directory.pluck(:sort_key).uniq
     return unless @current_index = params[:page] || @page_index.first
     @previous_index = @page_index[@page_index.index(@current_index) - 1]
     @next_index = @page_index[@page_index.index(@current_index) - 1]

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -21,11 +21,13 @@ class Project < ApplicationRecord
   has_many :surveys, dependent: :destroy
 
   before_create :set_slug
+  before_create :set_sort_key
+
   after_create :make_settings
   after_create :create_consequence_guide
 
-  scope :for_directory, -> { where(public: true, setup_complete: true, is_flagged: false).order("name ASC") }
-  scope :starting_with, ->(letter) { where("name ILIKE ?", letter + '%') }
+  scope :for_directory, -> { where(public: true, setup_complete: true, is_flagged: false).order("sort_key ASC") }
+  scope :starting_with, ->(letter) { where(sort_key: letter) }
 
   def accepting_issues?
     public? && !paused?
@@ -176,6 +178,10 @@ class Project < ApplicationRecord
 
   def create_consequence_guide
     ConsequenceGuide.create(project_id: id)
+  end
+
+  def set_sort_key
+    self.sort_key = name[0].downcase
   end
 
   def set_slug

--- a/app/views/directory/index.html.erb
+++ b/app/views/directory/index.html.erb
@@ -10,7 +10,7 @@
       </li>
       <% @page_index.each do |i| %>
         <li class="page-item <%= @current_index == i ? 'active' : '' %>">
-          <a class="page-link" href="?page=<%= i %>"><%= i %></a>
+          <a class="page-link" href="?page=<%= i %>"><%= i.upcase %></a>
         </li>
       <% end %>
       <li class="page-item">

--- a/db/migrate/20190327010650_projects_sort_key.rb
+++ b/db/migrate/20190327010650_projects_sort_key.rb
@@ -1,0 +1,6 @@
+class ProjectsSortKey < ActiveRecord::Migration[5.2]
+  def change
+    add_column :projects, :sort_key, :string, default: ""
+    add_index :projects, :sort_key
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_26_234755) do
+ActiveRecord::Schema.define(version: 2019_03_27_010650) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -324,9 +324,11 @@ ActiveRecord::Schema.define(version: 2019_03_26_234755) do
     t.integer "duration"
     t.string "frequency"
     t.string "attendees"
+    t.string "sort_key", default: ""
     t.index ["account_id"], name: "index_projects_on_account_id"
     t.index ["organization_id"], name: "index_projects_on_organization_id"
     t.index ["slug"], name: "index_projects_on_slug", unique: true
+    t.index ["sort_key"], name: "index_projects_on_sort_key"
   end
 
   create_table "respondent_templates", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -5,4 +5,8 @@ namespace :projects do
     Project.all.each{ |project| Role.create(project: project, account: project.account, is_owner: true) }
   end
 
+  desc 'Set sort keys for existing projects'
+  task :sort_keys => :environment do
+    Project.all.each{ |project| project.update_attribute(:sort_key, project.name[0].downcase) }
+  end
 end


### PR DESCRIPTION
We welcome contributions involving code, documentation, or design. If you'd like to contribute, please check out [our guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

Please refer to our [contributing guidelines](https://github.com/ContributorCovenant/beacon/blob/release/CONTRIBUTING.md) and follow the guidance in that document to improve the chances of your PR being merged.

## Problem
Directory sorting is case sensitive and not very performant.

## Solution
Add a sort key to projects.

## Todo
`rake projects:sort_keys`

## Notes for Reviewers
Anything that you want to tell the people who are going to review your pull request.

## Checklist
- [ ] Reasonable and adequate test coverage
- [x] Requires a database migration
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`
