### PR TITLE
Issue notification routing based on consequence levels

### DIFF
--- a/app/controllers/consequences_controller.rb
+++ b/app/controllers/consequences_controller.rb
@@ -44,7 +44,8 @@ class ConsequencesController < ApplicationController
       :severity,
       :label,
       :action,
-      :consequence
+      :consequence,
+      :email_to_notify
     )
   end
 

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -7,6 +7,7 @@ class Issue < ApplicationRecord
   validates_presence_of :description
 
   belongs_to :consequence, optional: true
+  belongs_to :reporter_consequence, optional: true, class_name: "Consequence"
   has_many :issue_events, dependent: :destroy
   has_many :issue_comments, dependent: :destroy
   has_many :notifications, dependent: :destroy

--- a/app/services/transparency_reporting_service.rb
+++ b/app/services/transparency_reporting_service.rb
@@ -15,6 +15,7 @@ class TransparencyReportingService
       next unless i.closed_at
       (i.closed_at - i.created_at).to_f / 1.day
     end.compact
+    return unless resolution_days.any?
     (resolution_days.sum / resolution_days.size).to_i
   end
 

--- a/app/views/consequence_guides/_consequence_organization.html.erb
+++ b/app/views/consequence_guides/_consequence_organization.html.erb
@@ -5,6 +5,11 @@
       <p><%= consequence.action %></p>
       <h3>Consequence</h3>
       <p><%= consequence.consequence %></p>
+      <% if consequence.email_to_notify.present? %>
+        <div class="alert alert-info">
+          <p>An additional notification will be sent to <%= consequence.email_to_notify %> when a reporter selects this level for their issue.</p>
+        </div>
+      <% end %>
       <% if current_account.can_manage_organization_consequence_guide?(@organization) %>
         <a onclick="toggle_show_and_form_views('consequence-<%= consequence.severity %>')">Edit</a>
       <% end %>
@@ -35,6 +40,14 @@
           <div class="form-group">
             <%= f.label :consequence %><br />
             <%= f.text_area :consequence, rows: 5, class: "form-control" %>
+          </div>
+
+          <div class="form-group">
+            <p>All moderators will be notified when an issue is opened, but if you
+            want an additional notification with this label to go to an external
+            email address, enter it below.</p>
+            <%= f.label :email_to_notify, "Additional email notification to" %><br />
+            <%= f.text_field :email_to_notify, class: "form-control" %>
           </div>
 
           <div class="actions">

--- a/app/views/consequence_guides/_consequence_project.html.erb
+++ b/app/views/consequence_guides/_consequence_project.html.erb
@@ -5,6 +5,11 @@
       <p><%= consequence.action %></p>
       <h3>Consequence</h3>
       <p><%= consequence.consequence %></p>
+      <% if consequence.email_to_notify.present? %>
+        <div class="alert alert-info">
+          <p>An additional notification will be sent to <%= consequence.email_to_notify %> when a reporter selects this level for their issue.</p>
+        </div>
+      <% end %>
       <% if current_account.can_manage_project_consequence_guide?(@project) %>
         <a onclick="toggle_show_and_form_views('consequence-<%= consequence.severity %>')">Edit</a>
       <% end %>
@@ -35,6 +40,14 @@
           <div class="form-group">
             <%= f.label :consequence %><br />
             <%= f.text_area :consequence, rows: 5, class: "form-control" %>
+          </div>
+
+          <div class="form-group">
+            <p>All moderators will be notified when an issue is opened, but if you
+            want an additional notification with this label to go to an external
+            email address, enter it below.</p>
+            <%= f.label :email_to_notify, "Additional email notification to" %><br />
+            <%= f.text_field :email_to_notify, class: "form-control" %>
           </div>
 
           <div class="actions">

--- a/app/views/consequence_guides/_organization.html.erb
+++ b/app/views/consequence_guides/_organization.html.erb
@@ -4,7 +4,7 @@
   <p><b>Important:</b> If you clone the guide from another source, all of your current issues will lose their associated severity.</p>
 
   <%= form_for guide, url: clone_organization_consequence_guide_path(@organization) do |f| %>
-    <div class="form-group col-sm-6">
+    <div class="form-group">
       <label for="consequence_guide_default_source">Clone from</label>
       <%= f.select :default_source, @available_guides.map(&:titleize), class: "form-control", include_blank: "Select..." %>
     </div>
@@ -35,24 +35,30 @@
     <div class="col">
       <h2>New Consequence</h2>
       <%= form_for guide.consequences.new, url: organization_consequence_guide_consequences_path(@organization, @guide) do |f| %>
-        <div class="form-group col-sm-6">
+        <div class="form-group">
           <%= f.label :label %><br />
           <%= f.text_field :label, autofocus: true, class: "form-control" %>
         </div>
 
-        <div class="form-group col-sm-6">
+        <div class="form-group">
           <%= f.label :severity %>
           <%= f.select :severity, severities, class: "form-control" %>
         </div>
 
-        <div class="form-group col-sm-6">
+        <div class="form-group">
           <%= f.label :action %><br />
           <%= f.text_area :action, class: "form-control" %>
         </div>
 
-        <div class="form-group col-sm-6">
+        <div class="form-group">
           <%= f.label :consequence %><br />
           <%= f.text_area :consequence, class: "form-control" %>
+        </div>
+
+        <div class="form-group">
+          <p>All moderators will be notified when an issue is opened, but if you want an additional notification with this label to go to an external email address, enter it below.</p>
+          <%= f.label :email_to_notify, "Additional email notification to" %><br />
+          <%= f.text_field :email_to_notify, class: "form-control" %>
         </div>
 
         <div class="actions">

--- a/app/views/consequence_guides/_project.html.erb
+++ b/app/views/consequence_guides/_project.html.erb
@@ -4,7 +4,7 @@
   <p><b>Important:</b> If you clone the guide from another source, all of your current issues will lose their associated severity.</p>
 
   <%= form_for guide, url: clone_project_consequence_guide_path(@project) do |f| %>
-    <div class="form-group col-sm-6">
+    <div class="form-group">
       <label for="consequence_guide_default_source">Clone from</label>
       <%= f.select :default_source, @available_guides.map(&:titleize), class: "form-control", include_blank: "Select..." %>
     </div>
@@ -35,24 +35,30 @@
     <div class="col">
       <h2>New Consequence</h2>
       <%= form_for guide.consequences.new, url: project_consequence_guide_consequences_path(@project, @guide) do |f| %>
-        <div class="form-group col-sm-6">
+        <div class="form-group">
           <%= f.label :label %><br />
           <%= f.text_field :label, autofocus: true, class: "form-control" %>
         </div>
 
-        <div class="form-group col-sm-6">
+        <div class="form-group">
           <%= f.label :severity %>
           <%= f.select :severity, severities, class: "form-control" %>
         </div>
 
-        <div class="form-group col-sm-6">
+        <div class="form-group">
           <%= f.label :action %><br />
           <%= f.text_area :action, class: "form-control" %>
         </div>
 
-        <div class="form-group col-sm-6">
+        <div class="form-group">
           <%= f.label :consequence %><br />
           <%= f.text_area :consequence, class: "form-control" %>
+        </div>
+
+        <div class="form-group">
+          <p>All moderators will be notified when an issue is opened, but if you want an additional notification with this label to go to an external email address, enter it below.</p>
+          <%= f.label :email_to_notify, "Additional email notification to" %><br />
+          <%= f.text_field :email_to_notify, class: "form-control" %>
         </div>
 
         <div class="actions">

--- a/app/views/issues/_moderator_view.html.erb
+++ b/app/views/issues/_moderator_view.html.erb
@@ -1,11 +1,15 @@
 <div class="row mt-3">
 
   <div class="col">
-    <div>
-      <div style="mix-blend-mode: exclusion; padding: .25em;">
-        <%= @issue.description %>
-      </div>
+    <div style="mix-blend-mode: exclusion; padding: .25em;">
+      <%= @issue.description %>
     </div>
+    <% if @reporter_consequence %>
+      <p class="mt-5">
+        The reporter identified this as a level <%= @reporter_consequence.severity %>
+        issue (<%= @reporter_consequence.label %>).
+      </p>
+    <% end %>
   </div>
 
   <div class="col" style="border-left: 1px solid #eee;">

--- a/app/views/issues/_reporter_view.html.erb
+++ b/app/views/issues/_reporter_view.html.erb
@@ -8,6 +8,11 @@
       </div>
     </div>
 
+    <% if consequence = @issue.consequence || @issue.reporter_consequence %>
+      <h2 class="mt-3">Classification</h2>
+      <p><%= consequence.action %></p>
+    <% end %>
+
     <% if @issue.resolved? && current_account.can_complete_survey_on_issue?(@issue, @project) %>
       <h2>Feedback</h2>
       <p>Would you like to complete a short survey on the resolution of this issue?</p>

--- a/app/views/issues/new.html.erb
+++ b/app/views/issues/new.html.erb
@@ -23,9 +23,23 @@ this project can be found <%= link_to "here", @project.coc_url, target: "_new" %
 <%= form_for @issue, url: project_issues_path(@project) do |f| %>
 
   <div class="form-group">
-    <label>Describe the incident in as much detail as you can.</label><br />
+    <label for="issue_description">Describe the incident in as much detail as you can.</label><br />
     <%= f.text_area :description, class: "form-control", rows: 10 %>
   </div>
+
+  <% if @consequences.any? %>
+    <div class="form-group">
+      <label>Select the corresponding violation type (optional).</label>
+      <div class="input-group mb-3" role="group" aria-label="Violation type">
+        <% @consequences.each do |consequence| %>
+          <div class="input-group-text" style="width: 100%; white-space: normal; text-align: left;">
+            <%= f.radio_button :reporter_consequence_id, consequence.id %>
+            <%= f.label consequence.action, class: "ml-2" %><br />
+          </div>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
 
   <div class="form-group">
     <label>Provide any relevant URLs.</label><br />

--- a/app/views/projects/_issues.html.erb
+++ b/app/views/projects/_issues.html.erb
@@ -4,7 +4,6 @@
       <th>Issue</th>
       <th>Description</th>
       <th>Opened</th>
-      <th class="hide-portrait-phone">Updated</th>
       <th>Status</th>
     </tr>
   </thead>
@@ -20,7 +19,6 @@
         </td>
         <td><%= truncate(issue.description, length: 50) %></td>
         <td><%= issue.created_at.in_time_zone.strftime("%a %b %d %Y at %l:%M %p %Z") %></td>
-        <td class="hide-portrait-phone"><%= issue.updated_at.in_time_zone.strftime("%a %b %d %Y at %l:%M %p %Z") %></td>
         <td><%= issue.aasm_state.titleize %></td>
       </tr>
     <% end %>

--- a/app/views/static_content/main.html.erb
+++ b/app/views/static_content/main.html.erb
@@ -12,7 +12,7 @@
   <div class="row mt-5">
 
     <div class="col-sm">
-      <div class="card mr-5 mt-2" style="height: 14em;"" style="height: 14em;"">
+      <div class="card mr-5 mt-2" style="min-height: 16rem;">
         <div class="card-body">
           <h2 class="card-title">Browse the Directory</h2>
           <p class="card-text">View a directory of <%= @project_count %> events and open source projects that are currently using Beacon.</p>
@@ -24,7 +24,7 @@
     <% if current_account %>
       <% if current_account.can_create_project? %>
         <div class="col-sm">
-          <div class="card mr-5 mt-2" style="height: 14em;"">
+          <div class="card mr-5 mt-2" style="min-height: 16rem;">
             <div class="card-body">
               <h2 class="card-title">Register a Project</h2>
               <p class="card-text">Register and configure a new project on Beacon.</p>
@@ -35,7 +35,7 @@
       <% end %>
       <% if current_account.can_create_organization? %>
         <div class="col-sm">
-          <div class="card mr-5 mt-2" style="height: 14em;"">
+          <div class="card mr-5 mt-2" style="min-height: 16rem;">
             <div class="card-body">
               <h2 class="card-title">Create an Organization</h2>
               <p class="card-text">Manage a portfolio of projects or events.</p>
@@ -47,7 +47,7 @@
 
     <% else %>
       <div class="col-sm">
-        <div class="card mr-5 mt-2" style="height: 14em;"">
+        <div class="card mr-5 mt-2" style="min-height: 16em;">
           <div class="card-body">
             <h2 class="card-title">Register</h2>
             <p class="card-text">Create an account to file a code of conduct issue or to set up your project or event on Beacon.</p>
@@ -57,7 +57,7 @@
       </div>
 
       <div class="col-sm">
-        <div class="card mr-5 mt-2" style="height: 14em;"">
+        <div class="card mr-5 mt-2" style="min-height: 16rem;">
           <div class="card-body">
             <h2 class="card-title">Sign In</h2>
             <p class="card-text">If you already have an account, sign in to access your projects or to open a code of conduct issue.</p>

--- a/db/migrate/20190328214151_add_reporter_consequence_to_issue.rb
+++ b/db/migrate/20190328214151_add_reporter_consequence_to_issue.rb
@@ -1,0 +1,6 @@
+class AddReporterConsequenceToIssue < ActiveRecord::Migration[5.2]
+  def change
+    add_column :issues, :reporter_consequence_id, :uuid
+    add_foreign_key :issues, :consequences, column: :reporter_consequence_id
+  end
+end

--- a/db/migrate/20190329010959_add_notification_email_to_consequence.rb
+++ b/db/migrate/20190329010959_add_notification_email_to_consequence.rb
@@ -1,0 +1,5 @@
+class AddNotificationEmailToConsequence < ActiveRecord::Migration[5.2]
+  def change
+    add_column :consequences, :email_to_notify, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_27_010650) do
+ActiveRecord::Schema.define(version: 2019_03_29_010959) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -166,6 +166,7 @@ ActiveRecord::Schema.define(version: 2019_03_27_010650) do
     t.text "consequence", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "email_to_notify"
     t.index ["consequence_guide_id"], name: "index_consequences_on_consequence_guide_id"
   end
 
@@ -246,6 +247,7 @@ ActiveRecord::Schema.define(version: 2019_03_27_010650) do
     t.text "resolution_text"
     t.datetime "resolved_at"
     t.uuid "consequence_id"
+    t.uuid "reporter_consequence_id"
   end
 
   create_table "notifications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -267,8 +269,8 @@ ActiveRecord::Schema.define(version: 2019_03_27_010650) do
     t.text "description"
     t.uuid "account_id"
     t.string "remote_org_name"
-    t.datetime "created_at", default: "2019-03-27 00:00:00"
-    t.datetime "updated_at", default: "2019-03-27 00:00:00"
+    t.datetime "created_at", default: "2019-03-28 00:00:00"
+    t.datetime "updated_at", default: "2019-03-28 00:00:00"
     t.boolean "is_flagged", default: false
     t.text "flagged_reason"
     t.index ["account_id"], name: "index_organizations_on_account_id"
@@ -401,6 +403,7 @@ ActiveRecord::Schema.define(version: 2019_03_27_010650) do
   add_foreign_key "invitations", "projects"
   add_foreign_key "issue_comments", "issues"
   add_foreign_key "issue_events", "issues"
+  add_foreign_key "issues", "consequences", column: "reporter_consequence_id"
   add_foreign_key "notifications", "issue_comments"
   add_foreign_key "notifications", "issues"
   add_foreign_key "notifications", "projects"


### PR DESCRIPTION
We welcome contributions involving code, documentation, or design. If you'd like to contribute, please check out [our guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

Please refer to our [contributing guidelines](https://github.com/ContributorCovenant/beacon/blob/release/CONTRIBUTING.md) and follow the guidance in that document to improve the chances of your PR being merged.

## Problem
Some organizations need to route new issue notifications based on the severity of the issue being opened.

## Solution
Allow reporters to select an impact level when they create an issue. Allow moderators to assign email addresses for additional notifications to levels in their Consequence Guides.

## Todo
Any follow-up tasks that need to happen before or after the PR is merged.

## Notes for Reviewers
Anything that you want to tell the people who are going to review your pull request.

## Checklist
- [ ] Reasonable and adequate test coverage
- [x] Requires a database migration
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`
