### PR TITLE
Cache notifications per account

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -94,7 +94,9 @@ class Account < ApplicationRecord
   end
 
   def notifications
-    @notifications ||= Notification.notifications_for_account(self)
+    @notifications ||= Rails.cache.fetch("#{cache_key_with_version}/notifications", expires_in: 6.hours) do
+      Notification.notifications_for_account(self)
+    end
   end
 
   def organizations


### PR DESCRIPTION
## Problem
Looking up notifications for accounts is expensive and happens in every request/response cycle.

## Solution
Cache notifications per account.

## Todo
Any follow-up tasks that need to happen before or after the PR is merged.

## Notes for Reviewers
Anything that you want to tell the people who are going to review your pull request.

## Checklist
- [ ] Reasonable and adequate test coverage
- [ ] Requires a database migration
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`
