### PR TITLE
use resque jobs with mailer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'premailer-rails'
 gem "puma", "~> 3.11"
 gem "recaptcha"
 gem "resque"
+gem "resque_mailer"
 gem "sass-rails", "~> 5.0"
 gem "sendgrid-ruby"
 gem "sentry-raven"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -317,6 +317,9 @@ GEM
       redis-namespace (~> 1.6)
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
+    resque_mailer (2.4.3)
+      actionmailer (>= 3.0)
+      activesupport (>= 3.0)
     retriable (3.1.2)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
@@ -488,6 +491,7 @@ DEPENDENCIES
   rails_layout!
   recaptcha
   resque
+  resque_mailer
   rspec-rails
   rubocop (~> 0.62.0)
   sass-rails (~> 5.0)

--- a/app/controllers/abuse_reports_controller.rb
+++ b/app/controllers/abuse_reports_controller.rb
@@ -22,9 +22,9 @@ class AbuseReportsController < ApplicationController
         project: @project
       )
       AdminMailer.with(
-        report: report,
-        project: @project
-      ).notify_on_abuse_report.deliver_now
+        report_id: report.id,
+        project_id: @project.id
+      ).notify_on_abuse_report.deliver!
     end
     flash[:message] = "Your report has been sent to Beacon administrative staff for review."
     redirect_to root_path

--- a/app/controllers/abuse_reports_controller.rb
+++ b/app/controllers/abuse_reports_controller.rb
@@ -24,7 +24,7 @@ class AbuseReportsController < ApplicationController
       AdminMailer.with(
         report_id: report.id,
         project_id: @project.id
-      ).notify_on_abuse_report.deliver!
+      ).notify_on_abuse_report.deliver
     end
     flash[:message] = "Your report has been sent to Beacon administrative staff for review."
     redirect_to root_path

--- a/app/controllers/account_project_blocks_controller.rb
+++ b/app/controllers/account_project_blocks_controller.rb
@@ -70,7 +70,7 @@ class AccountProjectBlocksController < ApplicationController
       account_id: @account.id,
       report_id: @report.id,
       reason: block_params[:reason]
-    ).notify_on_flag_request.deliver!
+    ).notify_on_flag_request.deliver
   end
 
   def scope_project

--- a/app/controllers/account_project_blocks_controller.rb
+++ b/app/controllers/account_project_blocks_controller.rb
@@ -66,11 +66,11 @@ class AccountProjectBlocksController < ApplicationController
 
   def notify_on_account_flag_requested
     AdminMailer.with(
-      reporter: current_account,
-      account: @account,
-      report: @report,
+      reporter_id: current_account.id,
+      account_id: @account.id,
+      report_id: @report.id,
       reason: block_params[:reason]
-    ).notify_on_flag_request.deliver_now
+    ).notify_on_flag_request.deliver!
   end
 
   def scope_project

--- a/app/controllers/contact_messages_controller.rb
+++ b/app/controllers/contact_messages_controller.rb
@@ -28,7 +28,7 @@ class ContactMessagesController < ApplicationController
   def notify_on_new_contact_message
     AdminMailer.with(
       contact_message: @contact_message
-    ).notify_on_new_contact_message.deliver_now
+    ).notify_on_new_contact_message.deliver!
   end
 
 end

--- a/app/controllers/contact_messages_controller.rb
+++ b/app/controllers/contact_messages_controller.rb
@@ -28,7 +28,7 @@ class ContactMessagesController < ApplicationController
   def notify_on_new_contact_message
     AdminMailer.with(
       contact_message: @contact_message
-    ).notify_on_new_contact_message.deliver!
+    ).notify_on_new_contact_message.deliver
   end
 
 end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -36,8 +36,8 @@ class InvitationsController < ApplicationController
     if recaptcha_success && invitation.save
       flash[:info] = "Invitation sent."
       InvitationsMailer.with(
-        invitation: invitation
-      ).send_invitation.deliver_now
+        invitation_id: invitation.id
+      ).send_invitation.deliver!
     else
       ActivityLoggingService.log(current_account, :recaptcha_failures) unless recaptcha_success
       flash[:error] = invitation.errors.full_messages

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -37,7 +37,7 @@ class InvitationsController < ApplicationController
       flash[:info] = "Invitation sent."
       InvitationsMailer.with(
         invitation_id: invitation.id
-      ).send_invitation.deliver!
+      ).send_invitation.deliver
     else
       ActivityLoggingService.log(current_account, :recaptcha_failures) unless recaptcha_success
       flash[:error] = invitation.errors.full_messages

--- a/app/controllers/issue_comments_controller.rb
+++ b/app/controllers/issue_comments_controller.rb
@@ -105,7 +105,7 @@ class IssueCommentsController < ApplicationController
           project_id: @project.id,
           issue_id: @issue.id,
           commenter_kind: commenter_kind
-        ).notify_of_new_comment.deliver!
+        ).notify_of_new_comment.deliver
       end
     else
       IssueNotificationsMailer.with(
@@ -113,7 +113,7 @@ class IssueCommentsController < ApplicationController
         project_id: @project.id,
         issue_id: @issue.id,
         commenter_kind: commenter_kind
-      ).notify_of_new_comment.deliver!
+      ).notify_of_new_comment.deliver
     end
   end
 

--- a/app/controllers/issue_comments_controller.rb
+++ b/app/controllers/issue_comments_controller.rb
@@ -102,18 +102,18 @@ class IssueCommentsController < ApplicationController
       if unnotified_moderators.any?
         IssueNotificationsMailer.with(
           email: unnotified_moderators.map(&:email),
-          project: @project,
-          issue: @issue,
+          project_id: @project.id,
+          issue_id: @issue.id,
           commenter_kind: commenter_kind
-        ).notify_of_new_comment.deliver_now
+        ).notify_of_new_comment.deliver!
       end
     else
       IssueNotificationsMailer.with(
         email: email,
-        project: @project,
-        issue: @issue,
+        project_id: @project.id,
+        issue_id: @issue.id,
         commenter_kind: commenter_kind
-      ).notify_of_new_comment.deliver_now
+      ).notify_of_new_comment.deliver!
     end
   end
 

--- a/app/controllers/issue_invitations_controller.rb
+++ b/app/controllers/issue_invitations_controller.rb
@@ -22,8 +22,8 @@ class IssueInvitationsController < ApplicationController
         email: account.email,
         project_name: project.name,
         text: project.respondent_template.populate_from(@issue, issue_url(@issue)),
-        issue: @issue
-      ).notify_existing_account_of_issue.deliver_now
+        issue_id: @issue.id
+      ).notify_existing_account_of_issue.deliver!
       AccountIssue.create(issue_id: @issue.id, account: account)
       NotificationService.notify(account_id: account.id,
                                  project_id: @project.id,
@@ -38,7 +38,7 @@ class IssueInvitationsController < ApplicationController
         email: account.email,
         project_name: project.name,
         text: project.respondent_template.populate_from(@issue, issue_url(@issue))
-      ).notify_new_account_of_issue.deliver_now
+      ).notify_new_account_of_issue.deliver!
     end
     @issue.update_attribute(:respondent_summary, invitation_params[:summary])
     flash[:message] = "The respondent has been notified and invited to comment on this issue."
@@ -54,7 +54,7 @@ class IssueInvitationsController < ApplicationController
       ReporterMailer.with(
         email: account.email,
         project_name: @issue.project.name
-      ).notify_existing_account_of_issue.deliver_now
+      ).notify_existing_account_of_issue.deliver!
       AccountIssue.create(issue_id: @issue.id, account: account)
       NotificationService.notify(account: account, project: @project, issue_id: @issue.id)
       @issue.update_attribute(:reporter_encrypted_id, EncryptionService.encrypt(account.id))

--- a/app/controllers/issue_invitations_controller.rb
+++ b/app/controllers/issue_invitations_controller.rb
@@ -23,7 +23,7 @@ class IssueInvitationsController < ApplicationController
         project_name: project.name,
         text: project.respondent_template.populate_from(@issue, issue_url(@issue)),
         issue_id: @issue.id
-      ).notify_existing_account_of_issue.deliver!
+      ).notify_existing_account_of_issue.deliver
       AccountIssue.create(issue_id: @issue.id, account: account)
       NotificationService.notify(account_id: account.id,
                                  project_id: @project.id,
@@ -38,7 +38,7 @@ class IssueInvitationsController < ApplicationController
         email: account.email,
         project_name: project.name,
         text: project.respondent_template.populate_from(@issue, issue_url(@issue))
-      ).notify_new_account_of_issue.deliver!
+      ).notify_new_account_of_issue.deliver
     end
     @issue.update_attribute(:respondent_summary, invitation_params[:summary])
     flash[:message] = "The respondent has been notified and invited to comment on this issue."
@@ -54,7 +54,7 @@ class IssueInvitationsController < ApplicationController
       ReporterMailer.with(
         email: account.email,
         project_name: @issue.project.name
-      ).notify_existing_account_of_issue.deliver!
+      ).notify_existing_account_of_issue.deliver
       AccountIssue.create(issue_id: @issue.id, account: account)
       NotificationService.notify(account: account, project: @project, issue_id: @issue.id)
       @issue.update_attribute(:reporter_encrypted_id, EncryptionService.encrypt(account.id))

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -157,21 +157,21 @@ class IssuesController < ApplicationController
         email: @issue.reporter_consequence.email_to_notify,
         project_id: @project.id,
         issue_id: @issue.id
-      ).notify_of_new_issue.deliver!
+      ).notify_of_new_issue.deliver
     end
 
     IssueNotificationsMailer.with(
       email: @project.moderator_emails,
       project_id: @project.id,
       issue_id: @issue.id
-    ).notify_of_new_issue.deliver!
+    ).notify_of_new_issue.deliver
 
     IssueNotificationsMailer.with(
       email: current_account.email,
       project_id: @project.id,
       issue_id: @issue.id,
       text: @project.autoresponder.populate_from(issue_url(@issue), project_url(@project))
-    ).autoresponder.deliver!
+    ).autoresponder.deliver
 
     NotificationService.enqueue_sms(@project.id, @issue.id)
   end
@@ -182,7 +182,7 @@ class IssuesController < ApplicationController
       emails: emails,
       project_id: @project.id,
       issue_id: @issue.id
-    ).notify_on_status_change.deliver!
+    ).notify_on_status_change.deliver
   end
 
   def scope_comments

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -155,23 +155,23 @@ class IssuesController < ApplicationController
     if @issue&.reporter_consequence&.email_to_notify
       IssueNotificationsMailer.with(
         email: @issue.reporter_consequence.email_to_notify,
-        project: @project,
-        issue: @issue
-      ).notify_of_new_issue.deliver_now
+        project_id: @project.id,
+        issue_id: @issue.id
+      ).notify_of_new_issue.deliver!
     end
 
     IssueNotificationsMailer.with(
       email: @project.moderator_emails,
-      project: @project,
-      issue: @issue
-    ).notify_of_new_issue.deliver_now
+      project_id: @project.id,
+      issue_id: @issue.id
+    ).notify_of_new_issue.deliver!
 
     IssueNotificationsMailer.with(
       email: current_account.email,
-      project: @project,
-      issue: @issue,
+      project_id: @project.id,
+      issue_id: @issue.id,
       text: @project.autoresponder.populate_from(issue_url(@issue), project_url(@project))
-    ).autoresponder.deliver_now
+    ).autoresponder.deliver!
 
     NotificationService.enqueue_sms(@project.id, @issue.id)
   end
@@ -180,9 +180,9 @@ class IssuesController < ApplicationController
     emails = [@issue.reporter.email, @issue.respondent.try(:email), @project.moderator_emails - [current_account.email]].flatten.compact
     IssueNotificationsMailer.with(
       emails: emails,
-      project: @project,
-      issue: @issue
-    ).notify_on_status_change.deliver_now
+      project_id: @project.id,
+      issue_id: @issue.id
+    ).notify_on_status_change.deliver!
   end
 
   def scope_comments

--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -56,10 +56,10 @@ class SurveysController < ApplicationController
       NotificationService.notify(account: moderator, project: @project, issue_id: @issue.id)
       IssueNotificationsMailer.with(
         email: moderator.email,
-        project: @project,
-        issue: @issue,
-        survey: @survey
-      ).notify_of_new_survey.deliver_now
+        project_id: @project.id,
+        issue_id: @issue.id,
+        survey_id: @survey.id
+      ).notify_of_new_survey.deliver!
     end
   end
 

--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -59,7 +59,7 @@ class SurveysController < ApplicationController
         project_id: @project.id,
         issue_id: @issue.id,
         survey_id: @survey.id
-      ).notify_of_new_survey.deliver!
+      ).notify_of_new_survey.deliver
     end
   end
 

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -1,9 +1,9 @@
 class AdminMailer < ApplicationMailer
 
   def notify_on_abuse_report
-    @report = params[:report]
-    @project = params[:project]
-    @reporter = @report.account
+    @report = AbuseReport.find(params[:report_id])
+    @project = Project.find(params[:project_id])
+    @reporter = @report&.account
     mail(to: Setting.emails(:abuse), subject: "Beacon: New Abuse Report")
   end
 
@@ -13,10 +13,10 @@ class AdminMailer < ApplicationMailer
   end
 
   def notify_on_flag_request
-    @reporter = params[:reporter]
-    @account = params[:account]
+    @reporter = Account.find(params[:reporter_id])
+    @account = Account.find(params[:account_id])
     @reason = params[:reason]
-    @report = params[:report]
+    @report = AbuseReport.find(params[:report_id])
     mail(to: Setting.emails(:abuse), subject: "Beacon: New Account Flag Request")
   end
 

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
-class ApplicationMailer < ActionMailer::Base
+class ApplicationMailer < AsyncMailer
   default from: Setting.emails(:robot)
   layout 'mailer'
 end

--- a/app/mailers/invitations_mailer.rb
+++ b/app/mailers/invitations_mailer.rb
@@ -1,7 +1,7 @@
 class InvitationsMailer < ApplicationMailer
 
   def send_invitation
-    @invitation = params[:invitation]
+    @invitation = Invitation.find(params[:invitation_id])
     @project_name = @invitation.project&.name
     @organization_name = @invitation.organization&.name
     @inviter_email = @invitation.account.email

--- a/app/mailers/issue_notifications_mailer.rb
+++ b/app/mailers/issue_notifications_mailer.rb
@@ -1,42 +1,43 @@
 class IssueNotificationsMailer < ApplicationMailer
 
   def autoresponder
-    @project = params[:project]
-    @issue = params[:issue]
+    assign_objects
     @email = params[:email]
     @text = params[:text]
     mail(to: @email, subject: "Beacon: #{@project.name} Issue ##{@issue.issue_number} has been opened")
   end
 
   def notify_on_status_change
-    @project = params[:project]
-    @issue = params[:issue]
+    assign_objects
     @emails = params[:emails]
     mail(bcc: @emails, subject: "Beacon: #{@project.name} Issue ##{@issue.issue_number} status has changed")
   end
 
   def notify_of_new_issue
-    @project = params[:project]
-    @issue = params[:issue]
+    assign_objects
     @email = params[:email]
     mail(to: @email, subject: "Beacon: #{@project.name} Issue ##{@issue.issue_number} has been opened")
   end
 
   def notify_of_new_comment
-    @project = params[:project]
-    @issue = params[:issue]
+    assign_objects
     @commenter_kind = params[:commenter_kind]
     @email = params[:email]
     mail(to: @email, subject: "Beacon: #{@project.name} Issue ##{@issue.issue_number} issue has a new comment")
   end
 
   def notify_of_new_survey
-    @project = params[:project]
-    @issue = params[:issue]
-    @survey = params[:survey]
+    assign_objects
+    @survey = Survey.find(params[:survey_id])
     @kind = @survey.kind
     @email = params[:email]
     mail(to: @email, subject: "Beacon: #{@project.name} Issue ##{@issue.issue_number} issue has a new survey")
   end
 
+  private
+
+  def assign_objects
+    @project = Project.find(params[:project_id])
+    @issue = Issue.find(params[:issue_id])
+  end
 end

--- a/app/mailers/respondent_mailer.rb
+++ b/app/mailers/respondent_mailer.rb
@@ -4,7 +4,7 @@ class RespondentMailer < ApplicationMailer
     @project_name = params[:project_name]
     @email = params[:email]
     @text = params[:text]
-    @issue = params[:issue]
+    @issue = Issue.find(params[:issue_id])
     mail(to: @email, subject: "Beacon: Your attention is needed on a code of conduct issue")
   end
 

--- a/config/initializers/resque_mailer.rb
+++ b/config/initializers/resque_mailer.rb
@@ -1,0 +1,3 @@
+class AsyncMailer < ActionMailer::Base
+  include Resque::Mailer
+end

--- a/spec/factories/account.rb
+++ b/spec/factories/account.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
 
     # Kate is a project owner for a medium-sized open source project with several moderators.
     factory :kate do
-      email { "kate@bush.com" }
+      email { "kate.bush@idolhands.com" }
     end
 
     # Peter is a moderator on a large enterprise open source project.


### PR DESCRIPTION
We welcome contributions involving code, documentation, or design. If you'd like to contribute, please check out [our guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

Please refer to our [contributing guidelines](https://github.com/ContributorCovenant/beacon/blob/release/CONTRIBUTING.md) and follow the guidance in that document to improve the chances of your PR being merged.

## Problem
[Move email delivery to a background job](https://github.com/ContributorCovenant/beacon/issues/144). This is an extension problem to [Move SMS to Background jobs](https://github.com/ContributorCovenant/beacon/issues/117)


## Solution
Used `resque_mailer` gem and send email asynchronously. 

## Todo
The feature must be QAd on staging.

## Notes for Reviewers
I passed the `ids` instead of `objects` for better consistency.

## Checklist
- [ ] Reasonable and adequate test coverage
- [ ] Requires a database migration
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`
