### PR TITLE
Invitation specs

### DIFF
--- a/app/controllers/consequences_controller.rb
+++ b/app/controllers/consequences_controller.rb
@@ -28,7 +28,7 @@ class ConsequencesController < ApplicationController
   end
 
   def destroy
-    @guide.consequences.find(:id).destroy
+    @guide.consequences.find(params[:id]).destroy
     if organization = @guide.organization
       redirect_to organization_consequence_guide_path(organization)
     else

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -24,7 +24,7 @@ class InvitationsController < ApplicationController
       invitation = Invitation.new(
         invitation_params.merge(
           account_id: current_account.id,
-          organization_id: organization.id,
+          organization_id: organization.id
         )
       )
     else
@@ -63,7 +63,7 @@ class InvitationsController < ApplicationController
         is_default_moderator: true
       )
       @invitation.destroy
-      redirect_to @invitation.organization and return if @invitation.is_owner?
+      redirect_to @invitation.organization && return if @invitation.is_owner?
       redirect_to projects_path
     end
   end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -25,7 +25,6 @@ class InvitationsController < ApplicationController
         invitation_params.merge(
           account_id: current_account.id,
           organization_id: organization.id,
-          is_default_moderator: true
         )
       )
     else
@@ -49,13 +48,22 @@ class InvitationsController < ApplicationController
   def accept
     flash[:info] = "You have accepted the invitation."
     if @invitation.project
-      Role.create(account: current_account, project_id: @invitation.project_id, is_owner: @invitation.is_owner)
+      Role.create(
+        account: current_account,
+        project_id: @invitation.project_id,
+        is_owner: @invitation.is_owner
+      )
       @invitation.destroy
       redirect_to @invitation.project
     elsif @invitation.organization
-      Role.create(account: current_account, organization_id: @invitation.organization_id, is_owner: @invitation.is_owner)
+      Role.create(
+        account: current_account,
+        organization_id: @invitation.organization_id,
+        is_owner: @invitation.is_owner,
+        is_default_moderator: true
+      )
       @invitation.destroy
-      redirect_to @invitation.project if @invitation.is_owner?
+      redirect_to @invitation.organization and return if @invitation.is_owner?
       redirect_to projects_path
     end
   end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -63,8 +63,11 @@ class InvitationsController < ApplicationController
         is_default_moderator: true
       )
       @invitation.destroy
-      redirect_to @invitation.organization && return if @invitation.is_owner?
-      redirect_to projects_path
+      if @invitation.is_owner?
+        redirect_to @invitation.organization
+      else
+        redirect_to projects_path
+      end
     end
   end
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -47,6 +47,10 @@ class Organization < ApplicationRecord
     !!is_flagged
   end
 
+  def moderator?(account)
+    moderators.include?(account)
+  end
+
   def moderators
     roles.where("is_default_moderator = ? OR is_owner = ?", true, true).map(&:account)
   end

--- a/app/views/consequence_guides/_consequence_organization.html.erb
+++ b/app/views/consequence_guides/_consequence_organization.html.erb
@@ -11,7 +11,7 @@
         </div>
       <% end %>
       <% if current_account.can_manage_organization_consequence_guide?(@organization) %>
-        <a onclick="toggle_show_and_form_views('consequence-<%= consequence.severity %>')">Edit</a>
+        <a href="#edit" onclick="toggle_show_and_form_views('consequence-<%= consequence.severity %>')">Edit</a>
       <% end %>
     </div>
   </div>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -183,7 +183,6 @@ ActiveRecord::Schema.define(version: 2019_03_30_235432) do
     t.string "uid"
     t.string "email"
     t.uuid "account_id"
-    t.string "oauth_token"
     t.string "token_encrypted"
     t.index ["account_id"], name: "index_credentials_on_account_id"
     t.index ["provider", "uid"], name: "index_credentials_on_provider_and_uid", unique: true
@@ -269,14 +268,11 @@ ActiveRecord::Schema.define(version: 2019_03_30_235432) do
     t.string "slug"
     t.text "description"
     t.uuid "account_id"
-    t.datetime "flagged_at"
-    t.text "flagged_reason"
-    t.datetime "confirmed_at"
-    t.string "confirmation_token_url"
     t.string "remote_org_name"
-    t.datetime "created_at", default: "2019-03-16 00:00:00"
-    t.datetime "updated_at", default: "2019-03-16 00:00:00"
+    t.datetime "created_at", default: "2019-04-02 00:00:00"
+    t.datetime "updated_at", default: "2019-04-02 00:00:00"
     t.boolean "is_flagged", default: false
+    t.text "flagged_reason"
     t.index ["account_id"], name: "index_organizations_on_account_id"
   end
 
@@ -321,7 +317,6 @@ ActiveRecord::Schema.define(version: 2019_03_30_235432) do
     t.uuid "organization_id"
     t.string "confirmation_token_url"
     t.string "repo_url"
-    t.datetime "start_date"
     t.boolean "is_event", default: false
     t.integer "duration"
     t.string "frequency"

--- a/spec/features/organization_spec.rb
+++ b/spec/features/organization_spec.rb
@@ -105,6 +105,7 @@ describe "organization management", type: :feature do
         click_on "Owners and Moderators"
         fill_in "invitation_email", with: moderator.email
         click_on "Invite Moderator"
+        expect(page).to have_content("Moderators Awaiting Confirmation")
         expect(moderator.invitations.count > 0).to be_truthy
       end
 
@@ -115,6 +116,7 @@ describe "organization management", type: :feature do
         fill_in "invitation_email", with: moderator.email
         check "invitation_is_owner"
         click_on "Invite Moderator"
+        expect(page).to have_content("Moderators Awaiting Confirmation")
         expect(moderator.invitations.count > 0).to be_truthy
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,10 @@ RSpec.configure do |config|
 
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
+  config.before(:each) do
+    allow_any_instance_of(ValidEmail2::Address).to receive(:valid_mx?) { true }
+  end
+
   # The settings below are suggested to provide a good initial experience
   # with RSpec, but feel free to customize to your heart's content.
   #   # This allows you to limit a spec run to individual examples or groups


### PR DESCRIPTION
## Problem
There weren't specs around the invitation process.

## Solution
Add feature specs for owner/moderator invitations for both orgs and projects.

