### PR TITLE
Fix bug with creating autoresponders for projects and orgs

### DIFF
--- a/app/models/autoresponder.rb
+++ b/app/models/autoresponder.rb
@@ -26,9 +26,13 @@ class Autoresponder < ApplicationRecord
   def update_org_projects
     return unless organization
     previous_text = changes[:text][0]
-    organization.projects.includes(:autoresponder).map(&:autoresponder).each do |autoresponder|
-      next unless autoresponder.text == previous_text # project has modified it
-      autoresponder.update_attribute(:text, changes[:text][1])
+    organization.projects.includes(:autoresponder).each do |project|
+      if autoresponder = project.autoresponder
+        next unless autoresponder.text == previous_text # project has modified it
+        autoresponder.update_attribute(:text, changes[:text][1])
+      else
+        Autoresponder.create(project_id: project.id, text: changes[:text][1])
+      end
     end
   end
 

--- a/app/models/autoresponder.rb
+++ b/app/models/autoresponder.rb
@@ -9,6 +9,10 @@ class Autoresponder < ApplicationRecord
 
   attr_accessor :default_source
 
+  def self.beacon_default
+    find_by(scope: "template")
+  end
+
   def populate_from(issue_url, project_url)
     text.gsub!("[[PROJECT_NAME]]", project.name)
     text.gsub!("[[CODE_OF_CONDUCT_URL]]", project.coc_url)

--- a/app/services/github_import_service.rb
+++ b/app/services/github_import_service.rb
@@ -34,6 +34,12 @@ class GithubImportService
           text: respondent_template.text
         )
       end
+      if autoresponder = organization.autoresponder
+        Autoresponder.create(
+          project_id: project.id,
+          text: autoresponder.text
+        )
+      end
       project.project_setting.touch
       project.check_setup_complete?
     end

--- a/app/services/gitlab_import_service.rb
+++ b/app/services/gitlab_import_service.rb
@@ -36,6 +36,13 @@ class GitlabImportService
         )
       end
 
+      if autoresponder = organization.autoresponder
+        Autoresponder.create(
+          project_id: project.id,
+          text: autoresponder.text
+        )
+      end
+
       project.project_setting.touch
       project.check_setup_complete?
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,8 +32,8 @@ Rails.application.routes.draw do
   resources :issues
 
   resources :organizations, param: :slug do
-    resource :autoresponder
     resources :invitations, only: [:create]
+    resource :autoresponder
     resource :respondent_template
     resource :consequence_guide do
       resources :consequences
@@ -47,6 +47,7 @@ Rails.application.routes.draw do
     post "import_projects_from_github", to: "organizations#import_projects_from_github"
     post "remove_moderator", to: "organizations#remove_moderator"
     post "clone_autoresponder", to: "autoresponders#clone"
+    patch "clone_autoresponder", to: "autoresponders#clone"
     post "clone_respondent_template", to: "respondent_templates#clone"
     patch "clone_respondent_template", to: "respondent_templates#clone"
   end
@@ -78,6 +79,7 @@ Rails.application.routes.draw do
     get "ownership", to: "projects#ownership"
     get "token", to: "projects#token"
     post "clone_autoresponder", to: "autoresponders#clone"
+    patch "clone_autoresponder", to: "autoresponders#clone"
     post "clone_respondent_template", to: "respondent_templates#clone"
     post "remove_moderator", to: "projects#remove_moderator"
     patch "clone_respondent_template", to: "respondent_templates#clone"

--- a/spec/features/organization_spec.rb
+++ b/spec/features/organization_spec.rb
@@ -2,6 +2,10 @@ require "rails_helper"
 
 describe "organization management", type: :feature do
 
+  before :all do
+    Autoresponder.create(scope: "template", text: "Thank you for opening a code of conduct issue")
+  end
+
   let(:maintainer) { FactoryBot.create(:danielle) }
 
   it "lets a user create an organization" do
@@ -71,6 +75,23 @@ describe "organization management", type: :feature do
       fill_in "respondent_template_text", with: "We are sad to inform you"
       click_on("Save")
       expect(page).to have_content("You have successfully updated the respondent template.")
+    end
+
+    it "lets a user add an autoresponder" do
+      login_as(maintainer, scope: :account)
+      visit root_path
+      click_on("My Organizations")
+      click_on(organization.name)
+      expect(page).to have_content("Setup Checklist")
+      click_on("Autoresponder")
+      expect(page).to have_content("Clone from")
+      select "Beacon Default", from: "autoresponder_default_source"
+      click_on("Clone")
+      expect(page).to have_content("Thank you for opening")
+      click_on("Edit")
+      fill_in "autoresponder_text", with: "Thanks so much"
+      click_on("Save")
+      expect(page).to have_content("You have successfully updated the autoresponder.")
     end
 
     it "lets a user create a project" do

--- a/spec/features/project_spec.rb
+++ b/spec/features/project_spec.rb
@@ -8,6 +8,8 @@ describe "The project setup process", type: :feature do
   before do
     allow_any_instance_of(ValidEmail2::Address).to receive(:valid_mx?) { true }
     Role.create(account_id: maintainer.id, project_id: project.id, is_owner: true)
+    Autoresponder.create(scope: "template", text: "Thank you for opening a code of conduct issue")
+    login_as(maintainer, scope: :account)
   end
 
   context "without an organization" do
@@ -27,7 +29,6 @@ describe "The project setup process", type: :feature do
     end
 
     it "lets a user create a project" do
-      login_as(maintainer, scope: :account)
       visit root_path
       click_on "My Projects"
       click_on("New Project")
@@ -41,7 +42,6 @@ describe "The project setup process", type: :feature do
     end
 
     it "lets a user confirm ownership" do
-      login_as(maintainer, scope: :account)
       visit root_path
       click_on "My Projects"
       click_on(project.name)
@@ -51,7 +51,6 @@ describe "The project setup process", type: :feature do
     end
 
     it "lets a user set up an impact and consequences guide" do
-      login_as(maintainer, scope: :account)
       visit root_path
       click_on "My Projects"
       click_on(project.name)
@@ -69,7 +68,6 @@ describe "The project setup process", type: :feature do
     end
 
     it "lets a user add a respondent template" do
-      login_as(maintainer, scope: :account)
       visit root_path
       click_on "My Projects"
       click_on(project.name)
@@ -83,8 +81,39 @@ describe "The project setup process", type: :feature do
       expect(page).to have_content("You have successfully updated the respondent template.")
     end
 
+    it "lets a user add an autoresponder" do
+      visit root_path
+      click_on "My Projects"
+      click_on(project.name)
+      click_on("Autoresponder")
+      expect(page).to have_content("Clone from")
+      select "Beacon Default", from: "autoresponder_default_source"
+      click_on("Clone")
+      expect(page).to have_content("Thank you for opening")
+      click_on("Edit")
+      fill_in "autoresponder_text", with: "Thanks so much"
+      click_on("Save")
+      expect(page).to have_content("You have successfully updated the autoresponder.")
+    end
+
+    it "lets a user set up an impact and consequences guide" do
+      visit root_path
+      click_on "My Projects"
+      click_on(project.name)
+      click_on("Impact and Consequences")
+      expect(page).to have_content("Clone from")
+      select "Beacon Default", from: "consequence_guide_default_source"
+      click_on("Clone")
+      expect(page).to have_content("Correction")
+      fill_in "consequence_label", with: "Disciplinary Action"
+      select "2", from: "consequence_severity"
+      fill_in "consequence_action", with: "Personal attacks"
+      fill_in "consequence_consequence", with: "Reprimand from moderators"
+      click_on("Update Guide")
+      expect(page).to have_content("Personal attacks")
+    end
+
     it "lets a user modify project settings" do
-      login_as(maintainer, scope: :account)
       visit root_path
       click_on "My Projects"
       click_on(project.name)
@@ -118,7 +147,6 @@ describe "The project setup process", type: :feature do
     end
 
     it "lets a user create a project" do
-      login_as(maintainer, scope: :account)
       visit root_path
       click_on "My Projects"
       click_on("New Project")
@@ -134,7 +162,6 @@ describe "The project setup process", type: :feature do
     end
 
     it "lets a user clone an impact and consequences guide" do
-      login_as(maintainer, scope: :account)
       visit root_path
       click_on "My Projects"
       click_on(org_project.name)
@@ -152,7 +179,6 @@ describe "The project setup process", type: :feature do
     end
 
     it "lets a user clone a respondent template" do
-      login_as(maintainer, scope: :account)
       visit root_path
       click_on "My Projects"
       click_on(org_project.name)
@@ -164,6 +190,21 @@ describe "The project setup process", type: :feature do
       fill_in "respondent_template_text", with: "We are sad to inform you"
       click_on("Save")
       expect(page).to have_content("You have successfully updated the respondent template.")
+    end
+
+    it "lets a user add an autoresponder" do
+      visit root_path
+      click_on "My Projects"
+      click_on(org_project.name)
+      click_on("Autoresponder")
+      expect(page).to have_content("Clone from")
+      select "Beacon Default", from: "autoresponder_default_source"
+      click_on("Clone")
+      expect(page).to have_content("Thank you for opening")
+      click_on("Edit")
+      fill_in "autoresponder_text", with: "Thanks so much"
+      click_on("Save")
+      expect(page).to have_content("You have successfully updated the autoresponder.")
     end
 
   end


### PR DESCRIPTION
We welcome contributions involving code, documentation, or design. If you'd like to contribute, please check out [our guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

Please refer to our [contributing guidelines](https://github.com/ContributorCovenant/beacon/blob/release/CONTRIBUTING.md) and follow the guidance in that document to improve the chances of your PR being merged.

## Problem
There was a bug preventing autoresponders from being created.

## Solution
Fix the bug so people can use the feature, Coraline!

## Todo
Any follow-up tasks that need to happen before or after the PR is merged.

## Notes for Reviewers
Anything that you want to tell the people who are going to review your pull request.

## Checklist
- [ ] Reasonable and adequate test coverage
- [ ] Requires a database migration
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`
