### PR TITLE
#53 Notify administrators of a project's name change

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -25,6 +25,7 @@ class Project < ApplicationRecord
 
   after_create :make_settings
   after_create :create_consequence_guide
+  after_commit :name_change_notification
 
   scope :for_directory, -> { where(public: true, setup_complete: true, is_flagged: false).order("sort_key ASC") }
   scope :starting_with, ->(letter) { where(sort_key: letter) }
@@ -190,5 +191,11 @@ class Project < ApplicationRecord
 
   def make_settings
     create_project_setting
+  end
+
+  private def name_change_notification
+    if saved_change_to_title?
+      ProjectMailer.name_change(project).deliver_later
+    end
   end
 end


### PR DESCRIPTION
## Problem
Bad actors might create projects with abusive names or descriptions.

## Solution
Notify the administrators of a project's name change