### PR TITLE
Add message to moderator invitation and optionally not send email

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -34,9 +34,13 @@ class InvitationsController < ApplicationController
     recaptcha_success = verify_recaptcha(model: invitation)
     if recaptcha_success && invitation.save
       flash[:info] = "Invitation sent."
-      InvitationsMailer.with(
-        invitation_id: invitation.id
-      ).send_invitation.deliver
+      if params[:commit] == "Get Invitation Link"
+        flash[:info] = "The invitation link for #{invitation.email} is #{invitations_url}."
+      else
+        InvitationsMailer.with(
+          invitation_id: invitation.id
+        ).send_invitation.deliver
+      end
     else
       ActivityLoggingService.log(current_account, :recaptcha_failures) unless recaptcha_success
       flash[:error] = invitation.errors.full_messages
@@ -94,7 +98,7 @@ class InvitationsController < ApplicationController
   end
 
   def invitation_params
-    params.require(:invitation).permit(:is_owner, :email)
+    params.require(:invitation).permit(:is_owner, :email, :message)
   end
 
   def scope_organization

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -25,6 +25,7 @@ class ProjectsController < ApplicationController
   end
 
   def remove_moderator
+    render_not_found && return unless current_account.can_remove_moderator?(@project)
     Role.where(account_id: params[:account_id], project_id: @project.id).destroy_all
     redirect_to project_moderators_path
   end

--- a/app/mailers/invitations_mailer.rb
+++ b/app/mailers/invitations_mailer.rb
@@ -6,6 +6,7 @@ class InvitationsMailer < ApplicationMailer
     @organization_name = @invitation.organization&.name
     @inviter_email = @invitation.account.email
     @subject_name = @project_name || @organization_name
+    @message = @invitation.message
     mail(to: @invitation.email, subject: "Beacon: Invitation to Moderate #{@subject_name}")
   end
 

--- a/app/models/concerns/permissions.rb
+++ b/app/models/concerns/permissions.rb
@@ -96,6 +96,10 @@ module Permissions
     project.moderator?(self)
   end
 
+  def can_remove_moderator?(subject)
+    subject.owner?(self)
+  end
+
   def can_view_organization?(organization)
     organization.owners.include? self
   end

--- a/app/views/invitations/index.html.erb
+++ b/app/views/invitations/index.html.erb
@@ -7,7 +7,7 @@
 <div class="container">
   <div class="row">
     <% @invitations.each do |invitation| %>
-      <div class="card mb-3 mr-3" style="width: 30%; min-height: 14rem">
+      <div class="card mb-3 mr-3" style="width: 50%; min-height: 14rem">
         <div class="card-body">
           <h2 class="card-title mb-1">
             <%= invitation.subject.name %>
@@ -17,6 +17,9 @@
               <%= invitation.is_owner? ? "become an owner" : "become a moderator" %>
               for <%= invitation.subject.name %>.
             </p>
+            <% if invitation.message %>
+              <p>Message: "<%= invitation.message %>"</p>
+            <% end %>
             <div class="actions">
               <%= button_to "Accept", invitation_accept_path(invitation), class: "btn btn-primary" %>
               <%= button_to "Decline", invitation_reject_path(invitation), class: "btn btn-danger" %>

--- a/app/views/invitations_mailer/send_invitation.html.inky
+++ b/app/views/invitations_mailer/send_invitation.html.inky
@@ -9,8 +9,16 @@
         <%= @inviter_email %> has invited you to join <%= @subject_name %> as
         <%= @invitation.is_owner? ? "an owner" : "a moderator" %>.
       </p>
-    </columns>
-  </row>
+      </columns>
+    </row>
+
+    <% if @message.present? %>
+      <row>
+        <columns>
+          <p>"<%= @message %>"</p>
+        </columns>
+      </row>
+    <% end %>
 
   <row>
     <columns>

--- a/app/views/invitations_mailer/send_invitation.txt.erb
+++ b/app/views/invitations_mailer/send_invitation.txt.erb
@@ -2,6 +2,10 @@ Invitation to Moderate <%= @subject_name %> %>
 
 <%= @inviter_email %> has invited you to join <%= @subject_name %> as <%= @invitation.is_owner? ? "an owner" : "a moderator" %>.
 
+<% if @message.present? %>
+  "<%= @message %>"
+<% end %>
+
 To accept or decline this invitation, visit:
 
   <%= invitations_url %>">

--- a/app/views/organizations/moderators.html.erb
+++ b/app/views/organizations/moderators.html.erb
@@ -10,7 +10,7 @@
           <% if @organization.owner?(moderator) %>
             (Owner)
           <% end %>
-          <% unless moderator == current_account %>
+          <% if moderator != current_account && current_account.can_remove_moderator?(@organization)%>
             <%= button_to "Remove", organization_remove_moderator_path(@organization), params: { account_id: moderator.id }, class: "btn btn-sm btn-danger" %>
           <% end %>
         </li>
@@ -18,9 +18,12 @@
     </ul>
     <% if @invitations.any? %>
       <h2>Moderators Awaiting Confirmation</h2>
+      <p>URL to share: <%= invitations_url %></p>
       <ul>
         <% @invitations.each do |invitation| %>
-          <li><%= invitation.email %></li>
+          <li>
+            <%= invitation.email %><br />
+          </li>
         <% end %>
       </ul>
     <% end %>
@@ -35,6 +38,10 @@
         <%= f.text_field :email %>
       </div>
       <div class="form-group col-sm-6">
+        <%= f.label :message, for: :message %><br />
+        <%= f.text_area :message %>
+      </div>
+      <div class="form-group col-sm-6">
         <%= f.check_box :is_owner, class: "mr-3", aria_label: "Make this account an owner" %>
         <label class="form-check-label" for="invitation_is_owner">Make Co-Owner</label>
       </div>
@@ -43,7 +50,8 @@
         <%= recaptcha_tags %>
       </div>
       <div class="actions">
-        <%= f.submit "Invite Moderator", class: "btn btn-primary" %>
+        <%= f.submit "Invite via Email", class: "btn btn-primary" %>
+        <%= f.submit "Get Invitation Link", class: "btn btn-primary" %>
       </div>
     <% end %>
   </div>

--- a/app/views/projects/moderators.html.erb
+++ b/app/views/projects/moderators.html.erb
@@ -10,7 +10,7 @@
           <% if @project.owner?(moderator) %>
             (Owner)
           <% end %>
-          <% unless moderator == current_account %>
+          <% if moderator != current_account && current_account.can_remove_moderator?(@project)%>
             <%= button_to "Remove", project_remove_moderator_path(@project), params: { account_id: moderator.id }, class: "btn btn-sm btn-danger" %>
           <% end %>
         </li>
@@ -18,9 +18,12 @@
     </ul>
     <% if @invitations.any? %>
       <h2>Moderators Awaiting Confirmation</h2>
+      <p>URL to share: <%= invitations_url %></p>
       <ul>
         <% @invitations.each do |invitation| %>
-          <li><%= invitation.email %></li>
+          <li>
+            <%= invitation.email %><br />
+          </li>
         <% end %>
       </ul>
     <% end %>
@@ -34,6 +37,10 @@
         <%= f.label :email, for: :email %><br />
         <%= f.text_field :email %>
       </div>
+      <div class="form-group col-sm-6">
+        <%= f.label :message, for: :message %><br />
+        <%= f.text_area :message %>
+      </div>
       <% if current_account.can_manage_project?(@project) %>
         <div class="form-group col-sm-6">
           <%= f.check_box :is_owner, class: "mr-3", aria_label: "Make this account an owner" %>
@@ -45,7 +52,8 @@
         <%= recaptcha_tags %>
       </div>
       <div class="actions">
-        <%= f.submit "Invite Moderator", class: "btn btn-primary" %>
+        <%= f.submit "Invite via Email", class: "btn btn-primary" %>
+        <%= f.submit "Get Invitation Link", class: "btn btn-primary" %>
       </div>
     <% end %>
   </div>

--- a/db/migrate/20190414195622_add_url_and_message_to_invitation.rb
+++ b/db/migrate/20190414195622_add_url_and_message_to_invitation.rb
@@ -1,0 +1,5 @@
+class AddUrlAndMessageToInvitation < ActiveRecord::Migration[5.2]
+  def change
+    add_column :invitations, :message, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_13_214725) do
+ActiveRecord::Schema.define(version: 2019_04_14_195622) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -184,6 +184,7 @@ ActiveRecord::Schema.define(version: 2019_04_13_214725) do
     t.string "uid"
     t.string "email"
     t.uuid "account_id"
+    t.string "oauth_token"
     t.string "token_encrypted"
     t.index ["account_id"], name: "index_credentials_on_account_id"
     t.index ["provider", "uid"], name: "index_credentials_on_provider_and_uid", unique: true
@@ -197,6 +198,7 @@ ActiveRecord::Schema.define(version: 2019_04_13_214725) do
     t.boolean "is_owner", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "message"
     t.index ["account_id"], name: "index_invitations_on_account_id"
     t.index ["organization_id"], name: "index_invitations_on_organization_id"
     t.index ["project_id"], name: "index_invitations_on_project_id"
@@ -269,11 +271,14 @@ ActiveRecord::Schema.define(version: 2019_04_13_214725) do
     t.string "slug"
     t.text "description"
     t.uuid "account_id"
-    t.string "remote_org_name"
-    t.datetime "created_at", default: "2019-04-13 00:00:00"
-    t.datetime "updated_at", default: "2019-04-13 00:00:00"
-    t.boolean "is_flagged", default: false
+    t.datetime "flagged_at"
     t.text "flagged_reason"
+    t.datetime "confirmed_at"
+    t.string "confirmation_token_url"
+    t.string "remote_org_name"
+    t.datetime "created_at", default: "2019-03-16 00:00:00"
+    t.datetime "updated_at", default: "2019-03-16 00:00:00"
+    t.boolean "is_flagged", default: false
     t.boolean "accept_issues_by_email", default: false
     t.index ["account_id"], name: "index_organizations_on_account_id"
   end
@@ -319,6 +324,7 @@ ActiveRecord::Schema.define(version: 2019_04_13_214725) do
     t.uuid "organization_id"
     t.string "confirmation_token_url"
     t.string "repo_url"
+    t.datetime "start_date"
     t.boolean "is_event", default: false
     t.integer "duration"
     t.string "frequency"

--- a/spec/features/moderator_spec.rb
+++ b/spec/features/moderator_spec.rb
@@ -302,12 +302,13 @@ describe "moderation", type: :feature do
 
     let(:new_moderator) { FactoryBot.create(:kate) }
 
-    it "lets a user invite a moderator" do
+    it "lets a user invite a moderator via email" do
       login_as(moderator, scope: :account)
       visit project_path(project)
       click_on "Moderators"
       fill_in "invitation_email", with: new_moderator.email
-      click_on "Invite Moderator"
+      fill_in "invitation_message", with: "I'd like you to help moderate"
+      click_on "Invite via Email"
       expect(page).to have_content("Moderators Awaiting Confirmation")
       expect(new_moderator.invitations.count > 0).to be_truthy
     end
@@ -317,8 +318,9 @@ describe "moderation", type: :feature do
       visit project_path(project)
       click_on "Moderators"
       fill_in "invitation_email", with: new_moderator.email
+      fill_in "invitation_message", with: "I'd like you to invite you as co-owner"
       check "invitation_is_owner"
-      click_on "Invite Moderator"
+      click_on "Invite via Email"
       expect(page).to have_content("Moderators Awaiting Confirmation")
       expect(new_moderator.invitations.count > 0).to be_truthy
     end

--- a/spec/features/organization_spec.rb
+++ b/spec/features/organization_spec.rb
@@ -136,7 +136,7 @@ describe "organization management", type: :feature do
         visit organization_path(organization)
         click_on "Owners and Moderators"
         fill_in "invitation_email", with: moderator.email
-        click_on "Invite Moderator"
+        click_on "Invite via Email"
         expect(page).to have_content("Moderators Awaiting Confirmation")
         expect(moderator.invitations.count > 0).to be_truthy
       end
@@ -147,7 +147,7 @@ describe "organization management", type: :feature do
         click_on "Owners and Moderators"
         fill_in "invitation_email", with: moderator.email
         check "invitation_is_owner"
-        click_on "Invite Moderator"
+        click_on "Invite via Email"
         expect(page).to have_content("Moderators Awaiting Confirmation")
         expect(moderator.invitations.count > 0).to be_truthy
       end


### PR DESCRIPTION
We welcome contributions involving code, documentation, or design. If you'd like to contribute, please check out [our guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

Please refer to our [contributing guidelines](https://github.com/ContributorCovenant/beacon/blob/release/CONTRIBUTING.md) and follow the guidance in that document to improve the chances of your PR being merged.

## Problem
Some project or org owners might want to send a personalized message as part of the moderator invitation. They also may want to send the moderator a link to the invitation, rather than having Beacon send it.

## Solution
Add an optional message field to the moderator invitation form, and display a link to the invitations page.

## Todo
Any follow-up tasks that need to happen before or after the PR is merged.

## Notes for Reviewers
Anything that you want to tell the people who are going to review your pull request.

## Checklist
- [x] Reasonable and adequate test coverage
- [x] Requires a database migration
- [x] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`
