### PR TITLE
Add option for moderator to report an account for abuse

### DIFF
--- a/app/views/admin/abuse_reports/show.html.erb
+++ b/app/views/admin/abuse_reports/show.html.erb
@@ -38,7 +38,7 @@
   <% if projects.any? %>
     <h2 class="mt-3">Associated Projects</h2>
     <ul>
-      <% project.each do |project| %>
+      <% projects.each do |project| %>
         <li>
           <%= link_to project.name, admin_project_path(project) %>
         </li>

--- a/app/views/reporters/show.html.erb
+++ b/app/views/reporters/show.html.erb
@@ -36,8 +36,12 @@
       <%= f.label "Reason" %><br />
       <%= f.text_area :reason, class: "form-control" %>
     </div>
+    <div class="form-group col-sm-6">
+      <%= f.check_box :report_for_abuse, class: "form-check-input" %>
+      <label class="form-check-label" for="account_project_block_report_for_abuse">Report account to Beacon admins</label>
+    </div>
     <div class="actions">
-      <%= f.submit "Block", class: "btn btn-danger", confirm: "Are you sure you want to unblock this account?" %>
+      <%= f.submit "Block", class: "btn btn-danger", confirm: "Are you sure you want to block this account?" %>
     </div>
   <% end %>
 </div>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -184,6 +184,7 @@ ActiveRecord::Schema.define(version: 2019_04_14_221727) do
     t.string "uid"
     t.string "email"
     t.uuid "account_id"
+    t.string "oauth_token"
     t.string "token_encrypted"
     t.index ["account_id"], name: "index_credentials_on_account_id"
     t.index ["provider", "uid"], name: "index_credentials_on_provider_and_uid", unique: true
@@ -270,11 +271,14 @@ ActiveRecord::Schema.define(version: 2019_04_14_221727) do
     t.string "slug"
     t.text "description"
     t.uuid "account_id"
+    t.datetime "flagged_at"
+    t.text "flagged_reason"
+    t.datetime "confirmed_at"
+    t.string "confirmation_token_url"
     t.string "remote_org_name"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean "is_flagged", default: false
-    t.text "flagged_reason"
     t.boolean "accept_issues_by_email", default: false
     t.index ["account_id"], name: "index_organizations_on_account_id"
   end
@@ -320,6 +324,7 @@ ActiveRecord::Schema.define(version: 2019_04_14_221727) do
     t.uuid "organization_id"
     t.string "confirmation_token_url"
     t.string "repo_url"
+    t.datetime "start_date"
     t.boolean "is_event", default: false
     t.integer "duration"
     t.string "frequency"

--- a/spec/features/moderator_spec.rb
+++ b/spec/features/moderator_spec.rb
@@ -231,6 +231,15 @@ describe "moderation", type: :feature do
         click_on "Block"
         expect(page).to have_content("This account is blocked from this project")
       end
+
+      it "allows the moderator to report the reporter for abuse" do
+        click_on "Details"
+        fill_in "account_project_block_reason", with: "This person is trolling."
+        check "account_project_block_report_for_abuse"
+        click_on "Block"
+        expect(page).to have_content("This account is blocked from this project")
+        expect(AbuseReport.count).to eq(1)
+      end
     end
   end
 


### PR DESCRIPTION
We welcome contributions involving code, documentation, or design. If you'd like to contribute, please check out [our guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

Please refer to our [contributing guidelines](https://github.com/ContributorCovenant/beacon/blob/release/CONTRIBUTING.md) and follow the guidance in that document to improve the chances of your PR being merged.

## Problem
When blocking a user, a moderator may also want to report the account to Beacon admins for abuse.

## Solution
Add a checkbox to the block form to also report the account.

## Todo
Any follow-up tasks that need to happen before or after the PR is merged.

## Notes for Reviewers
Anything that you want to tell the people who are going to review your pull request.

## Checklist
- [ ] Reasonable and adequate test coverage
- [ ] Requires a database migration
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`
