### PR TITLE
Strip emoji from project and org slugs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ gem "sprockets-es6"
 gem "turbolinks", "~> 5"
 gem "twilio-ruby"
 gem "uglifier", ">= 1.3.0"
+gem "unicode-emoji"
 gem "valid_email2"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -454,6 +454,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.5)
     unicode-display_width (1.4.1)
+    unicode-emoji (2.1.0)
     valid_email2 (3.0.0)
       activemodel (>= 3.2)
       mail (~> 2.5)
@@ -536,6 +537,7 @@ DEPENDENCIES
   twilio-ruby
   tzinfo-data
   uglifier (>= 1.3.0)
+  unicode-emoji
   valid_email2
   web-console (>= 3.3.0)
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -87,7 +87,7 @@ class Organization < ApplicationRecord
   end
 
   def set_slug
-    self.slug = name.downcase.gsub(/[^a-z0-9]/i, '_')
+    self.slug = name.downcase.gsub(/[^a-z0-9]/i, '_').gsub(Unicode::Emoji::REGEX, '').gsub(/[_]+/,'_')
   end
 
   def update_project_org_names

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -87,7 +87,7 @@ class Organization < ApplicationRecord
   end
 
   def set_slug
-    self.slug = name.downcase.gsub(/[^a-z0-9]/i, '_').gsub(Unicode::Emoji::REGEX, '').gsub(/[_]+/,'_')
+    self.slug = name.downcase.gsub(/[^a-z0-9]/i, '_').gsub(Unicode::Emoji::REGEX, '').gsub(/[_]+/, '_')
   end
 
   def update_project_org_names

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -187,7 +187,7 @@ class Project < ApplicationRecord
   end
 
   def set_slug
-    self.slug = name.downcase.gsub(/[^a-z0-9]/i, '_').gsub(Unicode::Emoji::REGEX, '').gsub(/[_]+/,'_')
+    self.slug = name.downcase.gsub(/[^a-z0-9]/i, '_').gsub(Unicode::Emoji::REGEX, '').gsub(/[_]+/, '_')
   end
 
   def make_settings

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -187,7 +187,7 @@ class Project < ApplicationRecord
   end
 
   def set_slug
-    self.slug = name.downcase.gsub(/[^a-z0-9]/i, '_')
+    self.slug = name.downcase.gsub(/[^a-z0-9]/i, '_').gsub(Unicode::Emoji::REGEX, '').gsub(/[_]+/,'_')
   end
 
   def make_settings

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Project, type: :model  do
+RSpec.describe Project, type: :model do
 
   let(:maintainer) { FactoryBot.build(:kate) }
   let(:project){ FactoryBot.create(:project, account: maintainer, name: "We 🖤 Ruby") }

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe Project, type: :model  do
+
+  let(:maintainer) { FactoryBot.build(:kate) }
+  let(:project){ FactoryBot.create(:project, account: maintainer, name: "We 🖤 Ruby") }
+
+  it "sanitizes the project slug" do
+    expect(project.slug).to eq("we_ruby")
+  end
+
+end


### PR DESCRIPTION
We welcome contributions involving code, documentation, or design. If you'd like to contribute, please check out [our guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

Please refer to our [contributing guidelines](https://github.com/ContributorCovenant/beacon/blob/release/CONTRIBUTING.md) and follow the guidance in that document to improve the chances of your PR being merged.

## Problem
https://www.coc-beacon.com/projects/we-🖤 -ruby/ isn't a valid URL.

## Solution
Regex all your cares (and emojis) away.

## Todo
Any follow-up tasks that need to happen before or after the PR is merged.

## Notes for Reviewers
Anything that you want to tell the people who are going to review your pull request.

## Checklist
- [ ] Reasonable and adequate test coverage
- [ ] Requires a database migration
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`