### PR TITLE
Add before_action to issue invitations controller

### DIFF
--- a/app/controllers/issue_invitations_controller.rb
+++ b/app/controllers/issue_invitations_controller.rb
@@ -1,5 +1,6 @@
 class IssueInvitationsController < ApplicationController
 
+  before_action :authenticate_account!
   before_action :scope_all
   before_action :enforce_permissions
 


### PR DESCRIPTION
We welcome contributions involving code, documentation, or design. If you'd like to contribute, please check out [our guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

Please refer to our [contributing guidelines](https://github.com/ContributorCovenant/beacon/blob/release/CONTRIBUTING.md) and follow the guidance in that document to improve the chances of your PR being merged.

## Problem
The IssueInvitations controller was missing the before action that requires authentication. Identified by @noahgibbs in #223 .

## Solution
Add the action.

## Todo
Any follow-up tasks that need to happen before or after the PR is merged.

## Notes for Reviewers
Anything that you want to tell the people who are going to review your pull request.

## Checklist
- [ ] Reasonable and adequate test coverage
- [ ] Requires a database migration
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`
