### PR TITLE
Create org-wide dashboard of issues

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,6 @@
-We welcome contributions involving code, documentation, or design. If you'd like to contribute, please check out [our guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).
+We welcome all contributions involving code, documentation, or design. If you'd like to contribute, please read our [guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CONTRIBUTING.md) and follow the guidance in that document to improve the chances of your PR being merged.
 
 All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).
-
-Please refer to our [contributing guidelines](https://github.com/ContributorCovenant/beacon/blob/release/CONTRIBUTING.md) and follow the guidance in that document to improve the chances of your PR being merged.
 
 ## Problem
 A concise description of the problem this pull request is intending to solve. Link to any relevant issues in the issue tracker.

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -54,8 +54,12 @@ class IssuesController < ApplicationController
 
   def show
     if @project.moderator?(current_account) || current_account.is_admin?
-      breadcrumb "Projects", projects_path
-      breadcrumb "#{@project.name} Issues", project_path(@project)
+      if organization = @project.organization
+        breadcrumb organization.name, organization_path(organization)
+      else
+        breadcrumb "Projects", projects_path
+      end
+      breadcrumb @project.name, project_path(@project)
     else
       breadcrumb "My Issues", issues_path
     end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -3,6 +3,7 @@ class OrganizationsController < ApplicationController
   before_action :authenticate_account!
   before_action :scope_organization, except: [:index, :new, :create]
   before_action :scope_projects, only: [:show, :update]
+  before_action :scope_issues, only: [:show, :update]
   before_action :enforce_view_permissions, except: [:index, :new, :create]
   before_action :enforce_management_permissions, only: [:edit, :update, :delete]
 
@@ -33,7 +34,6 @@ class OrganizationsController < ApplicationController
 
   def show
     breadcrumb @organization.name, organization_path(@organization)
-    @issues = ProjectIssue.issues_for_organization(@organization)
     if @organization.projects.count > 12
       @page_index = @organization.projects.order('name ASC').pluck(:name).map(&:first).uniq
       @current_index = params[:page] || @page_index.first
@@ -123,6 +123,10 @@ class OrganizationsController < ApplicationController
   def scope_organization
     @organization = Organization.find_by(slug: params[:slug]) || Organization.find_by(slug: params[:organization_slug])
     render_not_found unless @organization
+  end
+
+  def scope_issues
+    @issues = ProjectIssue.issues_for_organization(@organization)
   end
 
   def scope_projects

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -33,6 +33,7 @@ class OrganizationsController < ApplicationController
 
   def show
     breadcrumb @organization.name, organization_path(@organization)
+    @issues = ProjectIssue.issues_for_organization(@organization)
     if @organization.projects.count > 12
       @page_index = @organization.projects.order('name ASC').pluck(:name).map(&:first).uniq
       @current_index = params[:page] || @page_index.first

--- a/app/models/project_issue.rb
+++ b/app/models/project_issue.rb
@@ -5,6 +5,12 @@ class ProjectIssue < ApplicationRecord
 
   attr_accessor :issue_id
 
+  def self.issues_for_organization(organization)
+    encrypted_issue_ids = where(project_id: organization.projects.map(&:id)).pluck(:issue_encrypted_id)
+    issue_ids = encrypted_issue_ids.map{ |id| EncryptionService.decrypt(id) }
+    Issue.where(id: issue_ids)
+  end
+
   def self.issues_for_project(project_id)
     encrypted_issue_ids = where(project_id: project_id).pluck(:issue_encrypted_id)
     issue_ids = encrypted_issue_ids.map{ |id| EncryptionService.decrypt(id) }

--- a/app/views/organizations/_issues.html.erb
+++ b/app/views/organizations/_issues.html.erb
@@ -1,0 +1,28 @@
+<table class="table">
+  <thead>
+    <tr>
+      <th>Issue</th>
+      <th>Project</th>
+      <th>Description</th>
+      <th>Opened</th>
+      <th>Status</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% issues.each do |issue| %>
+      <tr>
+        <td>
+          <% count = current_account.notifications.for_issue(issue).size %>
+          <%= link_to issue.issue_number, project_issue_path(issue.project, issue) %>
+          <% if count > 0 %>
+            <span class="badge badge-pill badge-danger"><%= current_account.notifications.for_issue(issue).size %></span>
+          <% end %>
+        </td>
+        <td><%= issue.project.name %></td>
+        <td><%= truncate(issue.description, length: 50) %></td>
+        <td><%= issue.created_at.in_time_zone.strftime("%a %b %d %Y at %l:%M %p %Z") %></td>
+        <td><%= issue.aasm_state.titleize %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -83,42 +83,44 @@
   </div>
 </div>
 
-<h1 class="mt-5 mr-3">Issues</h1>
+<% if @issues.any? %>
+  <h1 class="mt-5 mr-3">Issues</h1>
 
-<ul class="nav nav-tabs mt-5 mb-3 responsive" id="nav-tab" role="tablist">
-  <li class="nav-item"><a class="nav-link active" id="nav-newissues-tab" data-toggle="pill" href="#nav-newissues" role="tab" aria-controls="nav-newissues" aria-selected="true">
-    New Issues <span class="badge badge-pill badge-danger"><%= @issues.submitted.size %></span>
-  </a></li>
-  <li class="nav-item"><a class="nav-link " id="nav-acknowledgedissues-tab" data-toggle="pill" href="#nav-acknowledgedissues" role="tab" aria-controls="nav-acknowledgedissues" aria-selected="false">
-    In Progress <span class="badge badge-pill badge-warning"><%= @issues.acknowledged.size + @issues.reopened.size %></span>
-  </a></li>
-  <li class="nav-item"><a class="nav-link " id="nav-resolvedissues-tab" data-toggle="pill" href="#nav-resolvedissues" role="tab" aria-controls="nav-resolvedissues" aria-selected="false">
-    Resolved <span class="badge badge-pill badge-light"><%= @issues.resolved.size %></span>
-  </a></li>
-  <li class="nav-item"><a class="nav-link " id="nav-dismissedissues-tab" data-toggle="pill" href="#nav-dismissedissues" role="tab" aria-controls="nav-dismissedissues" aria-selected="false">
-    Dismissed <span class="badge badge-pill badge-dark"><%= @issues.dismissed.size %></span>
-  </a></li>
-</ul>
+  <ul class="nav nav-tabs mt-5 mb-3 responsive" id="nav-tab" role="tablist">
+    <li class="nav-item"><a class="nav-link active" id="nav-newissues-tab" data-toggle="pill" href="#nav-newissues" role="tab" aria-controls="nav-newissues" aria-selected="true">
+      New Issues <span class="badge badge-pill badge-danger"><%= @issues.submitted.size %></span>
+    </a></li>
+    <li class="nav-item"><a class="nav-link " id="nav-acknowledgedissues-tab" data-toggle="pill" href="#nav-acknowledgedissues" role="tab" aria-controls="nav-acknowledgedissues" aria-selected="false">
+      In Progress <span class="badge badge-pill badge-warning"><%= @issues.acknowledged.size + @issues.reopened.size %></span>
+    </a></li>
+    <li class="nav-item"><a class="nav-link " id="nav-resolvedissues-tab" data-toggle="pill" href="#nav-resolvedissues" role="tab" aria-controls="nav-resolvedissues" aria-selected="false">
+      Resolved <span class="badge badge-pill badge-light"><%= @issues.resolved.size %></span>
+    </a></li>
+    <li class="nav-item"><a class="nav-link " id="nav-dismissedissues-tab" data-toggle="pill" href="#nav-dismissedissues" role="tab" aria-controls="nav-dismissedissues" aria-selected="false">
+      Dismissed <span class="badge badge-pill badge-dark"><%= @issues.dismissed.size %></span>
+    </a></li>
+  </ul>
 
-<div class="tab-content responsive" id="nav-tabContent">
+  <div class="tab-content responsive" id="nav-tabContent">
 
-  <div class="tab-pane fade show active" id="nav-newissues" role="tabpanel" aria-labelledby="nav-newissues-tab">
-    <%= render partial: "issues", locals: { issues: @issues.submitted } %>
+    <div class="tab-pane fade show active" id="nav-newissues" role="tabpanel" aria-labelledby="nav-newissues-tab">
+      <%= render partial: "issues", locals: { issues: @issues.submitted } %>
+    </div>
+
+    <div class="tab-pane fade" id="nav-acknowledgedissues" role="tabpanel" aria-labelledby="nav-newissues-tab">
+      <%= render partial: "issues", locals: { issues: @issues.acknowledged + @issues.reopened } %>
+    </div>
+
+    <div class="tab-pane fade" id="nav-resolvedissues" role="tabpanel" aria-labelledby="nav-newissues-tab">
+      <%= render partial: "issues", locals: { issues: @issues.resolved } %>
+    </div>
+
+    <div class="tab-pane fade" id="nav-dismissedissues" role="tabpanel" aria-labelledby="nav-newissues-tab">
+      <%= render partial: "issues", locals: { issues: @issues.dismissed } %>
+    </div>
+
   </div>
-
-  <div class="tab-pane fade" id="nav-acknowledgedissues" role="tabpanel" aria-labelledby="nav-newissues-tab">
-    <%= render partial: "issues", locals: { issues: @issues.acknowledged + @issues.reopened } %>
-  </div>
-
-  <div class="tab-pane fade" id="nav-resolvedissues" role="tabpanel" aria-labelledby="nav-newissues-tab">
-    <%= render partial: "issues", locals: { issues: @issues.resolved } %>
-  </div>
-
-  <div class="tab-pane fade" id="nav-dismissedissues" role="tabpanel" aria-labelledby="nav-newissues-tab">
-    <%= render partial: "issues", locals: { issues: @issues.dismissed } %>
-  </div>
-
-</div>
+<% end %>
 
 <h1 class="float-left mt-5 mr-3">Projects</h1>
 

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -83,6 +83,43 @@
   </div>
 </div>
 
+<h1 class="mt-5 mr-3">Issues</h1>
+
+<ul class="nav nav-tabs mt-5 mb-3 responsive" id="nav-tab" role="tablist">
+  <li class="nav-item"><a class="nav-link active" id="nav-newissues-tab" data-toggle="pill" href="#nav-newissues" role="tab" aria-controls="nav-newissues" aria-selected="true">
+    New Issues <span class="badge badge-pill badge-danger"><%= @issues.submitted.size %></span>
+  </a></li>
+  <li class="nav-item"><a class="nav-link " id="nav-acknowledgedissues-tab" data-toggle="pill" href="#nav-acknowledgedissues" role="tab" aria-controls="nav-acknowledgedissues" aria-selected="false">
+    In Progress <span class="badge badge-pill badge-warning"><%= @issues.acknowledged.size + @issues.reopened.size %></span>
+  </a></li>
+  <li class="nav-item"><a class="nav-link " id="nav-resolvedissues-tab" data-toggle="pill" href="#nav-resolvedissues" role="tab" aria-controls="nav-resolvedissues" aria-selected="false">
+    Resolved <span class="badge badge-pill badge-light"><%= @issues.resolved.size %></span>
+  </a></li>
+  <li class="nav-item"><a class="nav-link " id="nav-dismissedissues-tab" data-toggle="pill" href="#nav-dismissedissues" role="tab" aria-controls="nav-dismissedissues" aria-selected="false">
+    Dismissed <span class="badge badge-pill badge-dark"><%= @issues.dismissed.size %></span>
+  </a></li>
+</ul>
+
+<div class="tab-content responsive" id="nav-tabContent">
+
+  <div class="tab-pane fade show active" id="nav-newissues" role="tabpanel" aria-labelledby="nav-newissues-tab">
+    <%= render partial: "issues", locals: { issues: @issues.submitted } %>
+  </div>
+
+  <div class="tab-pane fade" id="nav-acknowledgedissues" role="tabpanel" aria-labelledby="nav-newissues-tab">
+    <%= render partial: "issues", locals: { issues: @issues.acknowledged + @issues.reopened } %>
+  </div>
+
+  <div class="tab-pane fade" id="nav-resolvedissues" role="tabpanel" aria-labelledby="nav-newissues-tab">
+    <%= render partial: "issues", locals: { issues: @issues.resolved } %>
+  </div>
+
+  <div class="tab-pane fade" id="nav-dismissedissues" role="tabpanel" aria-labelledby="nav-newissues-tab">
+    <%= render partial: "issues", locals: { issues: @issues.dismissed } %>
+  </div>
+
+</div>
+
 <h1 class="float-left mt-5 mr-3">Projects</h1>
 
 <% if @organization.setup_complete? && current_account.can_manage_organization?(@organization) %>


### PR DESCRIPTION
We welcome contributions involving code, documentation, or design. If you'd like to contribute, please check out [our guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

Please refer to our [contributing guidelines](https://github.com/ContributorCovenant/beacon/blob/release/CONTRIBUTING.md) and follow the guidance in that document to improve the chances of your PR being merged.

## Problem
Orgs may have a large number of projects, and it will be difficult to see what issues are open in which projects.

## Solution
Create an org-wide issues dashboard.

