### PR TITLE
Issue #139: Block login via HTTP proxies or Tor exit nodes

### DIFF
--- a/.env.development.sample
+++ b/.env.development.sample
@@ -32,3 +32,7 @@ THROTTLE_MINUTES=10 # Cache TTL
 ### Login request throttling (x requests / y seconds)
 LOGIN_THROTTLE_REQUESTS=10
 LOGIN_THROTTLE_SECONDS=20
+
+### Prevent logins via Proxy or Tor - comment these out to permit
+BLOCK_LOGIN_VIA_PROXY=true
+BLOCK_LOGIN_VIA_TOR=true

--- a/app/controllers/accounts/sessions_controller.rb
+++ b/app/controllers/accounts/sessions_controller.rb
@@ -4,7 +4,7 @@ module Accounts
   class SessionsController < Devise::SessionsController
     # before_action :configure_sign_in_params, only: [:create]
 
-    PROXY_HEADERS = %w(FORWARDED X_FORWARDED_FOR VIA USERAGENT_VIA PROXY_CONNECTION XPROXY_CONNECTION PC_REMOTE_ADDR CLIENT_IP)
+    PROXY_HEADERS = %w(FORWARDED X_FORWARDED_FOR VIA USERAGENT_VIA PROXY_CONNECTION XPROXY_CONNECTION PC_REMOTE_ADDR CLIENT_IP).freeze
 
     # GET /resource/sign_in
     # def new

--- a/app/controllers/accounts/sessions_controller.rb
+++ b/app/controllers/accounts/sessions_controller.rb
@@ -21,9 +21,6 @@ module Accounts
       set_flash_message!(:notice, :signed_in)
       sign_in(resource_name, resource)
 
-      # Since this happens after signin, we could set this per-organization in
-      # the future. Some organizations allow or require employees to use
-      # an HTTP proxy.
       if ENV["BLOCK_LOGIN_VIA_PROXY"]
         header_names = request.headers.to_h.keys.map { |k| k.upcase.tr("-", "_").gsub(/^HTTP_/, "") }
         bad_headers = PROXY_HEADERS & header_names
@@ -46,8 +43,6 @@ module Accounts
         end
       end
 
-      # This, too, could easily be set per-organization. It is not clear that it should
-      # be, though.
       if ENV["BLOCK_LOGIN_VIA_TOR"]
         if Tor::DNSEL.include?(current_account.current_sign_in_ip)
           # This is a correct login but it occurred via a Tor exit node, which isn't allowed.

--- a/app/controllers/accounts/sessions_controller.rb
+++ b/app/controllers/accounts/sessions_controller.rb
@@ -24,7 +24,7 @@ module Accounts
       # Since this happens after signin, we could set this per-organization in
       # the future. Some organizations allow or require employees to use
       # an HTTP proxy.
-      if ENV["BEACON_BLOCK_LOGIN_VIA_PROXY"]
+      if ENV["BLOCK_LOGIN_VIA_PROXY"]
         header_names = request.headers.to_h.keys.map { |k| k.upcase.tr("-", "_").gsub(/^HTTP_/, "") }
         bad_headers = PROXY_HEADERS & header_names
         unless bad_headers.empty?
@@ -48,7 +48,7 @@ module Accounts
 
       # This, too, could easily be set per-organization. It is not clear that it should
       # be, though.
-      if ENV["BEACON_BLOCK_LOGIN_VIA_TOR"]
+      if ENV["BLOCK_LOGIN_VIA_TOR"]
         if Tor::DNSEL.include?(current_account.current_sign_in_ip)
           # This is a correct login but it occurred via a Tor exit node, which isn't allowed.
           # Since we don't want mysterious failures for honest users, we don't just return a normal

--- a/app/controllers/accounts/sessions_controller.rb
+++ b/app/controllers/accounts/sessions_controller.rb
@@ -1,6 +1,10 @@
+require File.join(Rails.root, "lib/tor")
+
 module Accounts
   class SessionsController < Devise::SessionsController
     # before_action :configure_sign_in_params, only: [:create]
+
+    PROXY_HEADERS = %w(FORWARDED X_FORWARDED_FOR VIA USERAGENT_VIA PROXY_CONNECTION XPROXY_CONNECTION PC_REMOTE_ADDR CLIENT_IP)
 
     # GET /resource/sign_in
     # def new
@@ -8,9 +12,54 @@ module Accounts
     # end
 
     # POST /resource/sign_in
-    # def create
-    #   super
-    # end
+    def create
+      # This code is from Devise's SessionsController - we need to check
+      # headers after successful login *without* rendering a result yet.
+      # It's hard to split the responsibility for rendering a response
+      # with a prewritten parent class.
+      self.resource = warden.authenticate!(auth_options)
+      set_flash_message!(:notice, :signed_in)
+      sign_in(resource_name, resource)
+
+      # Since this happens after signin, we could set this per-organization in
+      # the future. Some organizations allow or require employees to use
+      # an HTTP proxy.
+      if ENV["BEACON_BLOCK_LOGIN_VIA_PROXY"]
+        header_names = request.headers.to_h.keys.map { |k| k.upcase.tr("-", "_").gsub(/^HTTP_/, "") }
+        bad_headers = PROXY_HEADERS & header_names
+        unless bad_headers.empty?
+          # This is a correct login but it occurred via an HTTP proxy, which isn't allowed.
+          # Since we don't want mysterious failures for honest users, we don't just return a normal
+          # your-password-was-wrong login failure.
+          #
+          # The tradeoff here is that it's possible to try to brute-force passwords from
+          # a proxy or exit node since incorrect passwords can be distinguished from
+          # "no login via Tor/Proxy" responses. So it's more important to prevent
+          # brute-forcing via bcrypt, strong passwords and/or throttling.
+          #
+          # If we checked this *before* login, we would want to handle this
+          # differently - render_forbidden adds a suspicious activity log to the
+          # database, which can facilitate a DOS if it can be done without an
+          # account.
+          sign_out
+          return render_forbidden
+        end
+      end
+
+      # This, too, could easily be set per-organization. It is not clear that it should
+      # be, though.
+      if ENV["BEACON_BLOCK_LOGIN_VIA_TOR"]
+        if Tor::DNSEL.include?(current_account.current_sign_in_ip)
+          # This is a correct login but it occurred via a Tor exit node, which isn't allowed.
+          # Since we don't want mysterious failures for honest users, we don't just return a normal
+          # your-password-was-wrong login failure.
+          sign_out
+          return render_forbidden
+        end
+      end
+
+      respond_with resource, location: after_sign_in_path_for(resource)
+    end
 
     # DELETE /resource/sign_out
     # def destroy

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   mount_griddler
 
   devise_for :accounts, controllers: {
+    sessions: "accounts/sessions",
     registrations: "accounts/registrations",
     passwords: "accounts/passwords",
     omniauth_callbacks: 'accounts/omniauth_callbacks',

--- a/lib/tor.rb
+++ b/lib/tor.rb
@@ -108,45 +108,41 @@ module Tor
       target_port = options[:port] || TARGET_PORT
       [source_addr, target_port, target_addr, DNS_SUFFIX].join('.')
     end
-    class << self
-      alias hostname dnsname
+    class << self; alias hostname dnsname; end
 
-      protected
-
-      ##
-      # Resolves `host` into an IPv4 address using Ruby's default resolver.
-      #
-      # Optionally returns the IPv4 address with its octet order reversed.
-      #
-      # @example
-      #   Tor::DNSEL.getaddress("ruby-lang.org")  #=> "221.186.184.68"
-      #   Tor::DNSEL.getaddress("1.2.3.4")        #=> "1.2.3.4"
-      #   Tor::DNSEL.getaddress("1.2.3.4", true)  #=> "4.3.2.1"
-      #
-      # @param  [String, #to_s] host
-      # @param  [Boolean]       reversed
-      # @return [String]
-      def getaddress(host, reversed = false)
-        host =
-          case host.to_s
-          when Resolv::IPv6::Regex
-            raise ArgumentError, "not an IPv4 address: #{host}"
-          when Resolv::IPv4::Regex
-            host.to_s
-          else
-            begin
-              RESOLVER.each_address(host.to_s) do |addr|
-                return addr.to_s if addr.to_s =~ Resolv::IPv4::Regex
-              end
-              raise Resolv::ResolvError, "no address for #{host}"
-            rescue NoMethodError
-              # This is a workaround for Ruby bug #2614:
-              # @see http://redmine.ruby-lang.org/issues/show/2614
-              raise Resolv::ResolvError, "no address for #{host}"
+    ##
+    # Resolves `host` into an IPv4 address using Ruby's default resolver.
+    #
+    # Optionally returns the IPv4 address with its octet order reversed.
+    #
+    # @example
+    #   Tor::DNSEL.getaddress("ruby-lang.org")  #=> "221.186.184.68"
+    #   Tor::DNSEL.getaddress("1.2.3.4")        #=> "1.2.3.4"
+    #   Tor::DNSEL.getaddress("1.2.3.4", true)  #=> "4.3.2.1"
+    #
+    # @param  [String, #to_s] host
+    # @param  [Boolean]       reversed
+    # @return [String]
+    def self.getaddress(host, reversed = false)
+      host =
+        case host.to_s
+        when Resolv::IPv6::Regex
+          raise ArgumentError, "not an IPv4 address: #{host}"
+        when Resolv::IPv4::Regex
+          host.to_s
+        else
+          begin
+            RESOLVER.each_address(host.to_s) do |addr|
+              return addr.to_s if addr.to_s =~ Resolv::IPv4::Regex
             end
+            raise Resolv::ResolvError, "no address for #{host}"
+          rescue NoMethodError
+            # This is a workaround for Ruby bug #2614:
+            # @see http://redmine.ruby-lang.org/issues/show/2614
+            raise Resolv::ResolvError, "no address for #{host}"
           end
-        reversed ? host.split('.').reverse.join('.') : host
-      end
+        end
+      reversed ? host.split('.').reverse.join('.') : host
     end
   end
 end

--- a/lib/tor.rb
+++ b/lib/tor.rb
@@ -1,0 +1,151 @@
+# Originally copied from dryruby/tor.rb, at:
+# https://github.com/dryruby/tor.rb/blob/master/lib/tor/dnsel.rb
+
+require 'resolv'
+
+module Tor
+  ##
+  # Tor DNS Exit List (DNSEL) client.
+  #
+  # Unless the target IP address and port are explicitly specified, the
+  # query will be performed using a target IP address of "8.8.8.8" and a
+  # target port of 53. These correspond to the DNS protocol port on one of
+  # the [Google Public DNS](http://code.google.com/speed/public-dns/)
+  # servers, and they are guaranteed to be reachable from Tor's default exit
+  # policy.
+  #
+  # @example Checking source IP addresses
+  #   Tor::DNSEL.include?("185.220.101.21")               #=> true
+  #   Tor::DNSEL.include?("1.2.3.4")                     #=> false
+  #
+  # @example Checking source hostnames
+  #   Tor::DNSEL.include?("ennui.lostinthenoise.net")    #=> true
+  #   Tor::DNSEL.include?("myhost.example.org")          #=> false
+  #
+  # @example Specifying an explicit target port
+  #   Tor::DNSEL.include?("185.220.101.21", :port => 80)  #=> true
+  #   Tor::DNSEL.include?("185.220.101.21", :port => 25)  #=> false
+  #
+  # @example Specifying an explicit target IP address and port
+  #   Tor::DNSEL.include?(source_addr, :addr => target_addr, :port => target_port)
+  #   Tor::DNSEL.include?("185.220.101.21", :addr => myip, :port => myport)
+  #
+  # @example Using from a Rack application
+  #   Tor::DNSEL.include?(env['REMOTE_ADDR'] || env['REMOTE_HOST'], {
+  #     :addr => env['SERVER_NAME'],
+  #     :port => env['SERVER_PORT'],
+  #   })
+  #
+  # @see https://www.torproject.org/tordnsel/
+  # @see https://trac.torproject.org/projects/tor/wiki/TheOnionRouter/TorDNSExitList
+  # @see http://gitweb.torproject.org/tor.git?a=blob_plain;hb=HEAD;f=doc/contrib/torel-design.txt
+  module DNSEL
+    RESOLVER    = Resolv::DefaultResolver unless defined?(RESOLVER)
+    TARGET_ADDR = '8.8.8.8'.freeze        unless defined?(TARGET_ADDR)     # Google Public DNS
+    TARGET_PORT = 53                      unless defined?(TARGET_PORT)     # DNS
+    DNS_SUFFIX  = 'ip-port.exitlist.torproject.org'.freeze
+
+    ##
+    # Returns `true` if the Tor DNSEL includes `host`, `false` otherwise.
+    #
+    # If the DNS server is unreachable or the DNS query times out, returns
+    # `nil` to indicate that we don't have a definitive answer one way or
+    # another.
+    #
+    # @example
+    #   Tor::DNSEL.include?("185.220.101.21")    #=> true
+    #   Tor::DNSEL.include?("1.2.3.4")          #=> false
+    #
+    # @param  [String, #to_s]          host
+    # @param  [Hash{Symbol => Object}] options
+    # @option options [String, #to_s]  :addr ("8.8.8.8")
+    # @option options [Integer, #to_i] :port (53)
+    # @return [Boolean]
+    def self.include?(host, options = {})
+      begin
+        query(host, options) == '127.0.0.2'
+      rescue Resolv::ResolvError   # NXDOMAIN
+        false
+      rescue Resolv::ResolvTimeout
+        nil
+      rescue Errno::EHOSTUNREACH
+        nil
+      rescue Errno::EADDRNOTAVAIL
+        nil
+      end
+    end
+
+    ##
+    # Queries the Tor DNSEL for `host`, returning "172.0.0.2" if it is an
+    # exit node and raising a `Resolv::ResolvError` if it isn't.
+    #
+    # @example
+    #   Tor::DNSEL.query("185.220.101.21")       #=> "127.0.0.2"
+    #   Tor::DNSEL.query("1.2.3.4")             #=> Resolv::ResolvError
+    #
+    # @param  [String, #to_s]          host
+    # @param  [Hash{Symbol => Object}] options
+    # @option options [String, #to_s]  :addr ("8.8.8.8")
+    # @option options [Integer, #to_i] :port (53)
+    # @return [String]
+    # @raise  [Resolv::ResolvError] for an NXDOMAIN response
+    def self.query(host, options = {})
+      getaddress(dnsname(host, options))
+    end
+
+    ##
+    # Returns the DNS name used for Tor DNSEL queries of `host`.
+    #
+    # @example
+    #   Tor::DNSEL.dnsname("1.2.3.4")           #=> "4.3.2.1.53.8.8.8.8.ip-port.exitlist.torproject.org"
+    #
+    # @param  [String, #to_s]          host
+    # @param  [Hash{Symbol => Object}] options
+    # @option options [String, #to_s]  :addr ("8.8.8.8")
+    # @option options [Integer, #to_i] :port (53)
+    # @return [String]
+    def self.dnsname(host, options = {})
+      source_addr = getaddress(host, true)
+      target_addr = getaddress(options[:addr] || TARGET_ADDR, true)
+      target_port = options[:port] || TARGET_PORT
+      [source_addr, target_port, target_addr, DNS_SUFFIX].join('.')
+    end
+    class << self; alias_method :hostname, :dnsname; end
+
+  protected
+
+    ##
+    # Resolves `host` into an IPv4 address using Ruby's default resolver.
+    #
+    # Optionally returns the IPv4 address with its octet order reversed.
+    #
+    # @example
+    #   Tor::DNSEL.getaddress("ruby-lang.org")  #=> "221.186.184.68"
+    #   Tor::DNSEL.getaddress("1.2.3.4")        #=> "1.2.3.4"
+    #   Tor::DNSEL.getaddress("1.2.3.4", true)  #=> "4.3.2.1"
+    #
+    # @param  [String, #to_s] host
+    # @param  [Boolean]       reversed
+    # @return [String]
+    def self.getaddress(host, reversed = false)
+      host = case host.to_s
+        when Resolv::IPv6::Regex
+          raise ArgumentError.new("not an IPv4 address: #{host}")
+        when Resolv::IPv4::Regex
+          host.to_s
+        else
+          begin
+            RESOLVER.each_address(host.to_s) do |addr|
+              return addr.to_s if addr.to_s =~ Resolv::IPv4::Regex
+            end
+            raise Resolv::ResolvError.new("no address for #{host}")
+          rescue NoMethodError
+            # This is a workaround for Ruby bug #2614:
+            # @see http://redmine.ruby-lang.org/issues/show/2614
+            raise Resolv::ResolvError.new("no address for #{host}")
+          end
+      end
+      reversed ? host.split('.').reverse.join('.') : host
+    end
+  end
+end

--- a/spec/controllers/accounts_sessions_controller_spec.rb
+++ b/spec/controllers/accounts_sessions_controller_spec.rb
@@ -1,0 +1,158 @@
+require "rails_helper"
+
+RSpec.describe Accounts::SessionsController, type: :controller do
+  describe '#create' do
+    let(:moderator) { FactoryBot.create(:danielle) }
+    let(:reporter)  { FactoryBot.build(:exene) }
+    let!(:project)  { FactoryBot.create(:project, account: moderator) }
+
+    before do
+      Role.create(account_id: moderator.id, project_id: project.id, is_owner: true)
+
+      # We are explicitly setting the Devise mapping in order to
+      # bypass the router. That's because we are explicitly testing login,
+      # not logging in to test other stuff. This is not good practice for
+      # most tests in most cases.
+      @request.env["devise.mapping"] = Devise.mappings[:account]
+    end
+
+    context "attempted non-Tor login while not checking login via proxies or Tor exit nodes" do
+      before do
+        allow(ENV).to receive(:[]).with("BEACON_BLOCK_LOGIN_VIA_PROXY").and_return(nil)
+        allow(ENV).to receive(:[]).with("BEACON_BLOCK_LOGIN_VIA_TOR").and_return(nil)
+      end
+
+      it "permits login with no disallowed headers" do
+        post :create, params: {
+            "account[email]" => "danielle@dax.com",
+            "account[password]" => "1234567891011",
+        }
+        expect(controller.current_account).to be_truthy
+      end
+
+      # We're overriding SessionsController#create, so it's important to
+      # test this.
+      it "does not allow login with an incorrect password" do
+        post :create, params: {
+            "account[email]" => "danielle@dax.com",
+            "account[password]" => "7",
+        }
+        expect(controller.current_account).to be_falsy
+      end
+
+      # We're overriding SessionsController#create, so it's important to
+      # test this.
+      it "does not allow login with no password" do
+        post :create, params: {
+            "account[email]" => "danielle@dax.com",
+        }
+        expect(controller.current_account).to be_falsy
+      end
+
+      it "allows login with an X-FORWARDED-FOR header" do
+        # RSpec isn't passing headers in the POST: https://github.com/rspec/rspec-rails/issues/1655
+        request.headers.merge!({ "X-FORWARDED-FOR" => "some.domain.com" })
+        post :create, params: {
+            "account[email]" => "danielle@dax.com",
+            "account[password]" => "1234567891011",
+        }
+        expect(controller.current_account).to be_truthy
+      end
+    end
+
+    context "attempted non-Tor login while disallowing login via proxies and Tor exit nodes" do
+      before do
+        allow(ENV).to receive(:[]).with("BEACON_BLOCK_LOGIN_VIA_PROXY").and_return("true")
+        allow(ENV).to receive(:[]).with("BEACON_BLOCK_LOGIN_VIA_TOR").and_return("true")
+        allow(Tor::DNSEL).to receive(:include?).and_return(false) # Not a Tor exit node
+      end
+
+      it "permits login with no disallowed headers" do
+        post :create, params: {
+            "account[email]" => "danielle@dax.com",
+            "account[password]" => "1234567891011",
+        }
+        expect(controller.current_account).to be_truthy
+      end
+
+      # We're overriding SessionsController#create, so it's important to
+      # test this.
+      it "does not allow login with an incorrect password" do
+        post :create, params: {
+            "account[email]" => "danielle@dax.com",
+            "account[password]" => "7",
+        }
+        expect(controller.current_account).to be_falsy
+      end
+
+      # We're overriding SessionsController#create, so it's important to
+      # test this.
+      it "does not allow login with no password" do
+        post :create, params: {
+            "account[email]" => "danielle@dax.com",
+        }
+        expect(controller.current_account).to be_falsy
+      end
+    end
+
+    context "attempted login via proxy, while disallowing proxy and Tor login" do
+      before do
+        allow(ENV).to receive(:[]).with("BEACON_BLOCK_LOGIN_VIA_PROXY").and_return("true")
+        allow(ENV).to receive(:[]).with("BEACON_BLOCK_LOGIN_VIA_TOR").and_return("true")
+        allow(Tor::DNSEL).to receive(:include?).and_return(false) # Not a Tor exit node
+      end
+
+      it "does not allow login with an X-FORWARDED-FOR header" do
+        # RSpec isn't passing headers in the POST: https://github.com/rspec/rspec-rails/issues/1655
+        request.headers.merge!({ "X-FORWARDED-FOR" => "some.domain.com" })
+        post :create, params: {
+            "account[email]" => "danielle@dax.com",
+            "account[password]" => "1234567891011",
+        }
+        expect(controller.current_account).to be_falsy
+      end
+    end
+
+    context "attempted login via Tor exit node while that's forbidden" do
+      before do
+        allow(ENV).to receive(:[]).with("BEACON_BLOCK_LOGIN_VIA_PROXY").and_return("true")
+        allow(ENV).to receive(:[]).with("BEACON_BLOCK_LOGIN_VIA_TOR").and_return("true")
+        allow(Tor::DNSEL).to receive(:include?).and_return(true)
+      end
+
+      it "does not allow login via Tor exit node" do
+        post :create, params: {
+            "account[email]" => "danielle@dax.com",
+            "account[password]" => "1234567891011",
+        }
+        expect(controller.current_account).to be_falsy
+      end
+
+      it "does not allow login via Tor exit node with Proxy headers" do
+        request.headers.merge!({ "X-FORWARDED-FOR" => "some.domain.com" })
+        post :create, params: {
+            "account[email]" => "danielle@dax.com",
+            "account[password]" => "1234567891011",
+        }
+        expect(controller.current_account).to be_falsy
+      end
+    end
+
+    context "attempted login via any node when Tor DNSEL is down" do
+      before do
+        allow(ENV).to receive(:[]).with("BEACON_BLOCK_LOGIN_VIA_PROXY").and_return("true")
+        allow(ENV).to receive(:[]).with("BEACON_BLOCK_LOGIN_VIA_TOR").and_return("true")
+        allow(Tor::DNSEL).to receive(:include?).and_return(nil)  # This happens on timeout/error in Tor DNSEL
+      end
+
+      it "allows login when Tor status is unknown" do
+        post :create, params: {
+            "account[email]" => "danielle@dax.com",
+            "account[password]" => "1234567891011",
+        }
+        expect(controller.current_account).to be_truthy
+      end
+
+    end
+  end
+end

--- a/spec/controllers/accounts_sessions_controller_spec.rb
+++ b/spec/controllers/accounts_sessions_controller_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe Accounts::SessionsController, type: :controller do
 
       it "permits login with no disallowed headers" do
         post :create, params: {
-            "account[email]" => "danielle@dax.com",
-            "account[password]" => "1234567891011",
+          "account[email]" => "danielle@dax.com",
+          "account[password]" => "1234567891011"
         }
         expect(controller.current_account).to be_truthy
       end
@@ -34,8 +34,8 @@ RSpec.describe Accounts::SessionsController, type: :controller do
       # test this.
       it "does not allow login with an incorrect password" do
         post :create, params: {
-            "account[email]" => "danielle@dax.com",
-            "account[password]" => "7",
+          "account[email]" => "danielle@dax.com",
+          "account[password]" => "7"
         }
         expect(controller.current_account).to be_falsy
       end
@@ -44,17 +44,17 @@ RSpec.describe Accounts::SessionsController, type: :controller do
       # test this.
       it "does not allow login with no password" do
         post :create, params: {
-            "account[email]" => "danielle@dax.com",
+          "account[email]" => "danielle@dax.com"
         }
         expect(controller.current_account).to be_falsy
       end
 
       it "allows login with an X-FORWARDED-FOR header" do
         # RSpec isn't passing headers in the POST: https://github.com/rspec/rspec-rails/issues/1655
-        request.headers.merge!({ "X-FORWARDED-FOR" => "some.domain.com" })
+        request.headers["X-FORWARDED-FOR"] = "some.domain.com"
         post :create, params: {
-            "account[email]" => "danielle@dax.com",
-            "account[password]" => "1234567891011",
+          "account[email]" => "danielle@dax.com",
+          "account[password]" => "1234567891011"
         }
         expect(controller.current_account).to be_truthy
       end
@@ -69,8 +69,8 @@ RSpec.describe Accounts::SessionsController, type: :controller do
 
       it "permits login with no disallowed headers" do
         post :create, params: {
-            "account[email]" => "danielle@dax.com",
-            "account[password]" => "1234567891011",
+          "account[email]" => "danielle@dax.com",
+          "account[password]" => "1234567891011"
         }
         expect(controller.current_account).to be_truthy
       end
@@ -79,8 +79,8 @@ RSpec.describe Accounts::SessionsController, type: :controller do
       # test this.
       it "does not allow login with an incorrect password" do
         post :create, params: {
-            "account[email]" => "danielle@dax.com",
-            "account[password]" => "7",
+          "account[email]" => "danielle@dax.com",
+          "account[password]" => "7"
         }
         expect(controller.current_account).to be_falsy
       end
@@ -89,7 +89,7 @@ RSpec.describe Accounts::SessionsController, type: :controller do
       # test this.
       it "does not allow login with no password" do
         post :create, params: {
-            "account[email]" => "danielle@dax.com",
+          "account[email]" => "danielle@dax.com"
         }
         expect(controller.current_account).to be_falsy
       end
@@ -104,10 +104,10 @@ RSpec.describe Accounts::SessionsController, type: :controller do
 
       it "does not allow login with an X-FORWARDED-FOR header" do
         # RSpec isn't passing headers in the POST: https://github.com/rspec/rspec-rails/issues/1655
-        request.headers.merge!({ "X-FORWARDED-FOR" => "some.domain.com" })
+        request.headers["X-FORWARDED-FOR"] = "some.domain.com"
         post :create, params: {
-            "account[email]" => "danielle@dax.com",
-            "account[password]" => "1234567891011",
+          "account[email]" => "danielle@dax.com",
+          "account[password]" => "1234567891011"
         }
         expect(controller.current_account).to be_falsy
       end
@@ -122,17 +122,17 @@ RSpec.describe Accounts::SessionsController, type: :controller do
 
       it "does not allow login via Tor exit node" do
         post :create, params: {
-            "account[email]" => "danielle@dax.com",
-            "account[password]" => "1234567891011",
+          "account[email]" => "danielle@dax.com",
+          "account[password]" => "1234567891011"
         }
         expect(controller.current_account).to be_falsy
       end
 
       it "does not allow login via Tor exit node with Proxy headers" do
-        request.headers.merge!({ "X-FORWARDED-FOR" => "some.domain.com" })
+        request.headers["X-FORWARDED-FOR"] = "some.domain.com"
         post :create, params: {
-            "account[email]" => "danielle@dax.com",
-            "account[password]" => "1234567891011",
+          "account[email]" => "danielle@dax.com",
+          "account[password]" => "1234567891011"
         }
         expect(controller.current_account).to be_falsy
       end
@@ -142,13 +142,13 @@ RSpec.describe Accounts::SessionsController, type: :controller do
       before do
         allow(ENV).to receive(:[]).with("BLOCK_LOGIN_VIA_PROXY").and_return("true")
         allow(ENV).to receive(:[]).with("BLOCK_LOGIN_VIA_TOR").and_return("true")
-        allow(Tor::DNSEL).to receive(:include?).and_return(nil)  # This happens on timeout/error in Tor DNSEL
+        allow(Tor::DNSEL).to receive(:include?).and_return(nil) # This happens on timeout/error in Tor DNSEL
       end
 
       it "allows login when Tor status is unknown" do
         post :create, params: {
-            "account[email]" => "danielle@dax.com",
-            "account[password]" => "1234567891011",
+          "account[email]" => "danielle@dax.com",
+          "account[password]" => "1234567891011"
         }
         expect(controller.current_account).to be_truthy
       end

--- a/spec/controllers/accounts_sessions_controller_spec.rb
+++ b/spec/controllers/accounts_sessions_controller_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe Accounts::SessionsController, type: :controller do
 
     context "attempted non-Tor login while not checking login via proxies or Tor exit nodes" do
       before do
-        allow(ENV).to receive(:[]).with("BEACON_BLOCK_LOGIN_VIA_PROXY").and_return(nil)
-        allow(ENV).to receive(:[]).with("BEACON_BLOCK_LOGIN_VIA_TOR").and_return(nil)
+        allow(ENV).to receive(:[]).with("BLOCK_LOGIN_VIA_PROXY").and_return(nil)
+        allow(ENV).to receive(:[]).with("BLOCK_LOGIN_VIA_TOR").and_return(nil)
       end
 
       it "permits login with no disallowed headers" do
@@ -62,8 +62,8 @@ RSpec.describe Accounts::SessionsController, type: :controller do
 
     context "attempted non-Tor login while disallowing login via proxies and Tor exit nodes" do
       before do
-        allow(ENV).to receive(:[]).with("BEACON_BLOCK_LOGIN_VIA_PROXY").and_return("true")
-        allow(ENV).to receive(:[]).with("BEACON_BLOCK_LOGIN_VIA_TOR").and_return("true")
+        allow(ENV).to receive(:[]).with("BLOCK_LOGIN_VIA_PROXY").and_return("true")
+        allow(ENV).to receive(:[]).with("BLOCK_LOGIN_VIA_TOR").and_return("true")
         allow(Tor::DNSEL).to receive(:include?).and_return(false) # Not a Tor exit node
       end
 
@@ -97,8 +97,8 @@ RSpec.describe Accounts::SessionsController, type: :controller do
 
     context "attempted login via proxy, while disallowing proxy and Tor login" do
       before do
-        allow(ENV).to receive(:[]).with("BEACON_BLOCK_LOGIN_VIA_PROXY").and_return("true")
-        allow(ENV).to receive(:[]).with("BEACON_BLOCK_LOGIN_VIA_TOR").and_return("true")
+        allow(ENV).to receive(:[]).with("BLOCK_LOGIN_VIA_PROXY").and_return("true")
+        allow(ENV).to receive(:[]).with("BLOCK_LOGIN_VIA_TOR").and_return("true")
         allow(Tor::DNSEL).to receive(:include?).and_return(false) # Not a Tor exit node
       end
 
@@ -115,8 +115,8 @@ RSpec.describe Accounts::SessionsController, type: :controller do
 
     context "attempted login via Tor exit node while that's forbidden" do
       before do
-        allow(ENV).to receive(:[]).with("BEACON_BLOCK_LOGIN_VIA_PROXY").and_return("true")
-        allow(ENV).to receive(:[]).with("BEACON_BLOCK_LOGIN_VIA_TOR").and_return("true")
+        allow(ENV).to receive(:[]).with("BLOCK_LOGIN_VIA_PROXY").and_return("true")
+        allow(ENV).to receive(:[]).with("BLOCK_LOGIN_VIA_TOR").and_return("true")
         allow(Tor::DNSEL).to receive(:include?).and_return(true)
       end
 
@@ -140,8 +140,8 @@ RSpec.describe Accounts::SessionsController, type: :controller do
 
     context "attempted login via any node when Tor DNSEL is down" do
       before do
-        allow(ENV).to receive(:[]).with("BEACON_BLOCK_LOGIN_VIA_PROXY").and_return("true")
-        allow(ENV).to receive(:[]).with("BEACON_BLOCK_LOGIN_VIA_TOR").and_return("true")
+        allow(ENV).to receive(:[]).with("BLOCK_LOGIN_VIA_PROXY").and_return("true")
+        allow(ENV).to receive(:[]).with("BLOCK_LOGIN_VIA_TOR").and_return("true")
         allow(Tor::DNSEL).to receive(:include?).and_return(nil)  # This happens on timeout/error in Tor DNSEL
       end
 

--- a/spec/services/dnsel_spec.rb
+++ b/spec/services/dnsel_spec.rb
@@ -1,0 +1,92 @@
+#require File.join(File.dirname(__FILE__), 'spec_helper')
+
+require_relative "../../lib/tor"
+
+describe Tor::DNSEL do
+  before :all do
+    $VERBOSE = nil # silence 'warning: already initialized constant' notices
+    Resolv::DNS::Config::InitialTimeout = (ENV['TIMEOUT'] || 0.1).to_f
+  end
+
+  describe "Tor::DNSEL.include?" do
+    it "returns true for exit nodes" do
+      expect(Tor::DNSEL.include?('185.220.101.21')).to be_truthy
+    end
+
+    it "returns false for non-exit nodes" do
+      expect(Tor::DNSEL.include?('1.2.3.4')).to be_falsey
+    end
+
+    it "returns nil on DNS timeouts" do
+      begin
+        Tor::DNSEL::RESOLVER = Resolv::DNS.new
+        class << Tor::DNSEL::RESOLVER
+          def each_address(host, &block)
+            raise Resolv::ResolvTimeout
+          end
+        end
+        expect(Tor::DNSEL.include?('1.2.3.4')).to be_nil
+      ensure
+        Tor::DNSEL::RESOLVER = Resolv::DefaultResolver
+      end
+    end
+  end
+
+  describe "Tor::DNSEL.query" do
+    it "returns '127.0.0.2' for exit nodes" do
+      expect Tor::DNSEL.query('185.220.101.21') == '127.0.0.2'
+    end
+
+    it "raises ResolvError for non-exit nodes" do
+      expect(lambda { Tor::DNSEL.query('1.2.3.4') }).to raise_error(Resolv::ResolvError)
+    end
+  end
+
+  describe "Tor::DNSEL.dnsname without options" do
+    it "returns the correct DNS name" do
+      expect Tor::DNSEL.dnsname('1.2.3.4') == '4.3.2.1.53.8.8.8.8.ip-port.exitlist.torproject.org'
+    end
+  end
+
+  describe "Tor::DNSEL.dnsname with a target port" do
+    it "returns the correct DNS name" do
+      expect Tor::DNSEL.dnsname('1.2.3.4', :port => 25) == '4.3.2.1.25.8.8.8.8.ip-port.exitlist.torproject.org'
+    end
+  end
+
+  describe "Tor::DNSEL.dnsname with a target IP address" do
+    it "returns the correct DNS name" do
+      expect Tor::DNSEL.dnsname('1.2.3.4', :addr => '8.8.4.4') == '4.3.2.1.53.4.4.8.8.ip-port.exitlist.torproject.org'
+    end
+  end
+
+  describe "Tor::DNSEL.dnsname with a target IP address and port" do
+    it "returns the correct DNS name" do
+      expect Tor::DNSEL.dnsname('1.2.3.4', :addr => '8.8.4.4', :port => 25) == '4.3.2.1.25.4.4.8.8.ip-port.exitlist.torproject.org'
+    end
+  end
+
+  describe "Tor::DNSEL.getaddress" do
+    it "resolves IPv4 addresses" do
+      expect Tor::DNSEL.getaddress('127.0.0.1') == '127.0.0.1'
+      expect Tor::DNSEL.getaddress(IPAddr.new('127.0.0.1')) == '127.0.0.1'
+    end
+
+    it "resolves local hostnames" do
+      expect Tor::DNSEL.getaddress('localhost') == '127.0.0.1'
+    end
+
+    it "resolves public hostnames" do
+      expect(Tor::DNSEL.getaddress('google.com')).to match(Resolv::IPv4::Regex)
+    end
+
+    it "raises ArgumentError for IPv6 addresses" do
+      expect(lambda { Tor::DNSEL.getaddress('::1') }).to raise_error(ArgumentError)
+      expect(lambda { Tor::DNSEL.getaddress(IPAddr.new('::1')) }).to raise_error(ArgumentError)
+    end
+
+    it "raises ResolvError for nonexistent hostnames" do
+      expect(lambda { Tor::DNSEL.getaddress('foo.example.org') }).to raise_error(Resolv::ResolvError)
+    end
+  end
+end

--- a/spec/services/dnsel_spec.rb
+++ b/spec/services/dnsel_spec.rb
@@ -1,5 +1,3 @@
-#require File.join(File.dirname(__FILE__), 'spec_helper')
-
 require_relative "../../lib/tor"
 
 describe Tor::DNSEL do
@@ -18,17 +16,15 @@ describe Tor::DNSEL do
     end
 
     it "returns nil on DNS timeouts" do
-      begin
-        Tor::DNSEL::RESOLVER = Resolv::DNS.new
-        class << Tor::DNSEL::RESOLVER
-          def each_address(host, &block)
-            raise Resolv::ResolvTimeout
-          end
+      Tor::DNSEL::RESOLVER = Resolv::DNS.new
+      class << Tor::DNSEL::RESOLVER
+        def each_address(_host, &_block)
+          raise Resolv::ResolvTimeout
         end
-        expect(Tor::DNSEL.include?('1.2.3.4')).to be_nil
-      ensure
-        Tor::DNSEL::RESOLVER = Resolv::DefaultResolver
       end
+      expect(Tor::DNSEL.include?('1.2.3.4')).to be_nil
+    ensure
+      Tor::DNSEL::RESOLVER = Resolv::DefaultResolver
     end
   end
 
@@ -38,7 +34,7 @@ describe Tor::DNSEL do
     end
 
     it "raises ResolvError for non-exit nodes" do
-      expect(lambda { Tor::DNSEL.query('1.2.3.4') }).to raise_error(Resolv::ResolvError)
+      expect(-> { Tor::DNSEL.query('1.2.3.4') }).to raise_error(Resolv::ResolvError)
     end
   end
 
@@ -50,19 +46,19 @@ describe Tor::DNSEL do
 
   describe "Tor::DNSEL.dnsname with a target port" do
     it "returns the correct DNS name" do
-      expect Tor::DNSEL.dnsname('1.2.3.4', :port => 25) == '4.3.2.1.25.8.8.8.8.ip-port.exitlist.torproject.org'
+      expect Tor::DNSEL.dnsname('1.2.3.4', port: 25) == '4.3.2.1.25.8.8.8.8.ip-port.exitlist.torproject.org'
     end
   end
 
   describe "Tor::DNSEL.dnsname with a target IP address" do
     it "returns the correct DNS name" do
-      expect Tor::DNSEL.dnsname('1.2.3.4', :addr => '8.8.4.4') == '4.3.2.1.53.4.4.8.8.ip-port.exitlist.torproject.org'
+      expect Tor::DNSEL.dnsname('1.2.3.4', addr: '8.8.4.4') == '4.3.2.1.53.4.4.8.8.ip-port.exitlist.torproject.org'
     end
   end
 
   describe "Tor::DNSEL.dnsname with a target IP address and port" do
     it "returns the correct DNS name" do
-      expect Tor::DNSEL.dnsname('1.2.3.4', :addr => '8.8.4.4', :port => 25) == '4.3.2.1.25.4.4.8.8.ip-port.exitlist.torproject.org'
+      expect Tor::DNSEL.dnsname('1.2.3.4', addr: '8.8.4.4', port: 25) == '4.3.2.1.25.4.4.8.8.ip-port.exitlist.torproject.org'
     end
   end
 
@@ -81,12 +77,12 @@ describe Tor::DNSEL do
     end
 
     it "raises ArgumentError for IPv6 addresses" do
-      expect(lambda { Tor::DNSEL.getaddress('::1') }).to raise_error(ArgumentError)
-      expect(lambda { Tor::DNSEL.getaddress(IPAddr.new('::1')) }).to raise_error(ArgumentError)
+      expect(-> { Tor::DNSEL.getaddress('::1') }).to raise_error(ArgumentError)
+      expect(-> { Tor::DNSEL.getaddress(IPAddr.new('::1')) }).to raise_error(ArgumentError)
     end
 
     it "raises ResolvError for nonexistent hostnames" do
-      expect(lambda { Tor::DNSEL.getaddress('foo.example.org') }).to raise_error(Resolv::ResolvError)
+      expect(-> { Tor::DNSEL.getaddress('foo.example.org') }).to raise_error(Resolv::ResolvError)
     end
   end
 end


### PR DESCRIPTION
If the correct environment variable is set, block login via HTTP proxies or Tor exit nodes (Issue #139).

## Solution
In general, I did what I suggested I'd do (https://github.com/ContributorCovenant/beacon/issues/139#issuecomment-491535890).

One slight oddity about the solution: I allow successful login, including via Proxy or Tor, and then immediately log them out in the Proxy/Tor disallowed case. As it says in a comment in this PR, this allows brute-forcing of passwords via Proxy or Tor even though it doesn't allow valid logins. That's a tradeoff, and for now I think it's fine.

I did *not* use the last logged in IP for caching with Tor DNSEL. Due to the way I'm handling login, the last logged-in IP isn't a clean known-good address so that's not safe.

Env vars are BLOCK_LOGIN_VIA_PROXY and BLOCK_LOGIN_VIA_TOR.

Right now a failed login from *any* origin doesn't (and shouldn't) add DB logs, so this will add suspicious events *only* if a successful login happens and is then immediately reverted. This is to prevent denial-of-service via a flood of failed logins from Tor or HTTP proxies.

## Todo
It's worth considering whether we want this as a setting per-organization and perhaps filing a followup bug. Some older enterprises allow or require proxies. Tor is a possible requirement for journalists under oppressive regimes. In both cases, allowing those login types but only for those specific organizations seems like the best option. But that adds one more option to everybody's UX, so it's likely best to wait until somebody needs it.

I think this way is fine for v1.0.

## Notes for Reviewers
See "Solution", above.

## Checklist
* I added coverage for new functionality.
* No DB migration required.
* No new permissions.
* Env vars documented.
