### PR TITLE
Change the way the env var for false is interpreted

### DIFF
--- a/app/controllers/accounts/sessions_controller.rb
+++ b/app/controllers/accounts/sessions_controller.rb
@@ -30,7 +30,7 @@ module Accounts
       set_flash_message!(:notice, :signed_in)
       sign_in(resource_name, resource)
 
-      if ENV["BLOCK_LOGIN_VIA_PROXY"]
+      if ENV["BLOCK_LOGIN_VIA_PROXY"] == "true"
         header_names = request.headers.to_h.keys.map { |k| k.upcase.tr("-", "_").gsub(/^HTTP_/, "") }
         bad_headers = PROXY_HEADERS & header_names
         unless bad_headers.empty?


### PR DESCRIPTION
We welcome all contributions involving code, documentation, or design. If you'd like to contribute, please read our [guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CONTRIBUTING.md) and follow the guidance in that document to improve the chances of your PR being merged.

All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

## Problem
The proxy blocking code was expecting a boolean value for the corresponding environment variable, but it's a string.

## Solution
Fix it!

## Todo
Any follow-up tasks that need to happen before or after the PR is merged.

## Notes for Reviewers
Anything that you want to tell the people who are going to review your pull request.

## Checklist
- [ ] Reasonable and adequate test coverage
- [ ] Requires a database migration
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`
