### PR TITLE
Create show view for respondent templates

### DIFF
--- a/app/controllers/respondent_templates_controller.rb
+++ b/app/controllers/respondent_templates_controller.rb
@@ -15,6 +15,14 @@ class RespondentTemplatesController < ApplicationController
     end
   end
 
+  def show
+    if @project
+      @template = @project.respondent_template
+    else
+      @template = @organization.respondent_template
+    end
+  end
+
   def create
     if @project
       @template = RespondentTemplate.new(respondent_template_params.merge(project_id: @project.id))

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -57,7 +57,7 @@
             </li>
             <li>
               <% if @organization.respondent_template %>
-                <%= link_to "Respondent Template", edit_organization_respondent_template_path(@organization, @organization.respondent_template) %>
+                <%= link_to "Respondent Template", organization_respondent_template_path(@organization) %>
                 <% if !@organization.setup_complete? %>
                   <span class="badge badge-pill badge-success">
                     √

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -160,7 +160,7 @@
               <li>
                 <% if @project.respondent_template? %>
                 <% if current_account.can_manage_project?(@project) %>
-                  <%= link_to "Respondent Template", project_respondent_template_path(@project, @project.respondent_template) %>
+                  <%= link_to "Respondent Template", project_respondent_template_path(@project) %>
                 <% else %>
                   Respondent Template
                 <% end %>
@@ -252,7 +252,7 @@
               <% end %>
               <% if @project.respondent_template? %>
                 <li>
-                  <%= link_to "Respondent Template", edit_project_respondent_template_path(@project, @project.respondent_template) %>
+                  <%= link_to "Respondent Template", project_respondent_template_path(@project, @project.respondent_template) %>
                 </li>
               <% end %>
             <% end %>

--- a/app/views/respondent_templates/edit.html.erb
+++ b/app/views/respondent_templates/edit.html.erb
@@ -16,6 +16,7 @@
 
       <div class="actions">
         <%= f.submit "Save", class: "btn btn-primary" %>
+        <%= link_to "Cancel", @subject, class: "btn btn-primary" %>
       </div>
     <% end %>
   </div>

--- a/app/views/respondent_templates/show.html.erb
+++ b/app/views/respondent_templates/show.html.erb
@@ -1,0 +1,33 @@
+<% title "#{@subject.name}: Edit Respondent Template" %>
+
+<h1>Respondent Contact Template</h1>
+
+<p>This template will be used when you first contact the respondent of an issue.</p>
+
+<div class="row">
+
+  <div class="col">
+    <textarea disabled="disabled" rows="25" cols="50"><%= @template.text %></textarea>
+    <div class="actions">
+      <% if (@subject.is_a? Project) && current_account.can_manage_project_respondent_template?(@subject) %>
+        <%= link_to "Edit", edit_project_respondent_template_path(@subject), class: "btn btn-primary" %>
+      <% elsif (@subject.is_a? Organization) && current_account.can_manage_organization_respondent_template?(@subject) %>
+        <%= link_to "Edit", edit_organization_respondent_template_path(@subject), class: "btn btn-primary" %>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="col">
+    <h2>Tags</h2>
+    <p>The following tags will be auto-populated from your project and the issue when you contact a respondent:</p>
+
+    <ul>
+      <li>[[PROJECT_NAME]]</li>
+      <li>[[CODE_OF_CONDUCT_URL]]</li>
+      <li>[[VIOLATION_EXAMPLE]]: The example from the impact and consequence guide corresponding to the level of the issue.</li>
+      <li>[[CONSEQUENCE]]: The relevant consequence corresponding to the level of the issue's impact.</li>
+      <li>[[ISSUE_URL]]</li>
+    </ul>
+  </div>
+
+</div>


### PR DESCRIPTION
We welcome all contributions involving code, documentation, or design. If you'd like to contribute, please read our [guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CONTRIBUTING.md) and follow the guidance in that document to improve the chances of your PR being merged.

All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

## Problem
The default respondent template page was only available in 'edit' mode. See issue #240 .

## Solution
Create a 'view' mode as well.

## Todo
Any follow-up tasks that need to happen before or after the PR is merged.

## Notes for Reviewers
Anything that you want to tell the people who are going to review your pull request.

## Checklist
- [ ] Reasonable and adequate test coverage
- [ ] Requires a database migration
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`
