### PR TITLE
Fix event toggle logic

### DIFF
--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -38,22 +38,24 @@ settings for managing your project after it is created.</p>
     </div>
   <% end %>
 
+  <% display_event_controls_style = @project.is_event? ? "block" : "none" %>
+
   <div class="form-group col-sm-6">
     <%= f.check_box :is_event, class: "form-check-input", onclick: "toggleEventFields();" %>
     <label class="form-check-label" for="project_is_event">This is an event</label>
   </div>
 
-  <div class="event form-group col-sm-6" style="display: none;">
+  <div class="event form-group col-sm-6" style="display: <%= display_event_controls_style %>;">
     <%= f.label "Duration (days)" %><br />
     <%= f.text_field :duration, class: "form-control" %>
   </div>
 
-  <div class="event form-group col-sm-6" style="display: none;">
+  <div class="event form-group col-sm-6" style="display: <%= display_event_controls_style %>;">
     <%= f.label "Frequency" %><br />
     <%= f.select :frequency, [["Weekly", "weekly"], ["Biweekly", "biweekly"], ["Monthly", "monthly"], ["Annually", "annually"]], include_blank: "Select...", class: "form-control" %>
   </div>
 
-  <div class="event form-group col-sm-6" style="display: none;">
+  <div class="event form-group col-sm-6" style="display: <%= display_event_controls_style %>;">
     <%= f.label "# Attendees" %><br />
     <%= f.select :attendees, ["1-50", "50-100", "100-250", "250+"], include_blank: "Select...", class: "form-control" %>
   </div>


### PR DESCRIPTION
We welcome all contributions involving code, documentation, or design. If you'd like to contribute, please read our [guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CONTRIBUTING.md) and follow the guidance in that document to improve the chances of your PR being merged.

All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/ContributorCovenant/beacon/blob/release/CODE_OF_CONDUCT.md).

## Problem
If there is an error on the new project page, and the project is an event, when the page is reloaded the event fields are hidden. See issue #241 

## Solution
Preserve the event fields.

## Todo
Any follow-up tasks that need to happen before or after the PR is merged.

## Notes for Reviewers
Anything that you want to tell the people who are going to review your pull request.

## Checklist
- [ ] Reasonable and adequate test coverage
- [ ] Requires a database migration
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`
