### PR TITLE
Add coc to readme

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2018 Coraline Ada Ehmke
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ You can show your support for Beacon and help fund its development through [mont
 
 ## Contributing
 We welcome contributions involving code, documentation, or design. If you'd like to contribute, please check out [our guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CONTRIBUTING.md).
+
+## License
+
+The Beacon project is available under the [Apache 2.0 public license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Beacon was created with the goal of bringing this potential to every open source
 Beacon will be provided in a software-as-a-service (SaaS) model to reduce friction for getting started, so that maintainers can focus on managing their projects and communities with a minimum of setup.
 
 ## Feature Map
-A list of existing and planned features for Beacon can be found [here](https://github.com/ContributorCovenant/beacon/blob/release/feature_map.md).
+A list of existing and planned features for Beacon can be found [here](feature_map.md).
 
 ## Milestones
 
@@ -26,8 +26,12 @@ A list of existing and planned features for Beacon can be found [here](https://g
 You can show your support for Beacon and help fund its development through [monthly contributions to our Patreon](https://www.patreon.com/cocbeacon) or a [one-time donation to our fundraiser](https://www.gofundme.com/coc-beacon).
 
 ## Contributing
-We welcome contributions involving code, documentation, or design. If you'd like to contribute, please check out [our guide to contributing](https://github.com/ContributorCovenant/beacon/blob/release/CONTRIBUTING.md).
+We welcome contributions involving code, documentation, or design. If you'd like to contribute, please check out [our guide to contributing](CONTRIBUTING.md).
 
 ## License
 
-The Beacon project is available under the [Apache 2.0 public license](LICENSE).
+The Beacon project is available under the [Apache License Version 2.0](LICENSE).
+
+## Code of Conduct
+
+The CoC is available [here](CODE_OF_CONDUCT.md). It was adapted from the [Contributor Covenant](https://www.contributor-covenant.org), [version 1.4](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html).


### PR DESCRIPTION
## Problem
Readme doesn't mention the license or Code of Conduct in use. For new users in particular, important to display it in the main README, not just attached as separate markdown files.

## Solution
Updated readme. I also used [relative links](https://github.blog/2013-01-31-relative-links-in-markup-files/), which allows for easier migration if repository/branch name changes, and or if someone wants to copy parts of the readme for another project. 

## Checklist
- [ ] Reasonable and adequate test coverage
- [ ] Requires a database migration
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`
