### PR TITLE
Clone consequence guide on org project create

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -84,7 +84,7 @@ class Project < ApplicationRecord
   end
 
   def organization_consequence_guide
-    @organization_consequence_guide ||= organization && organization.consequence_guide
+    @organization_consequence_guide ||= organization&.consequence_guide
   end
 
   def organization_moderators
@@ -187,7 +187,7 @@ class Project < ApplicationRecord
   private
 
   def create_consequence_guide
-    guide = ConsequenceGuide.create(project_id: id)
+    ConsequenceGuide.create(project_id: id)
   end
 
   def set_sort_key

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -60,7 +60,6 @@ class Project < ApplicationRecord
   end
 
   def consequence_guide?
-    @has_consequence_guide = organization_consequence_guide.consequences.any?
     @has_consequence_guide ||= consequence_guide.consequences.any?
   end
 
@@ -189,8 +188,6 @@ class Project < ApplicationRecord
 
   def create_consequence_guide
     guide = ConsequenceGuide.create(project_id: id)
-    guide.clone_from(organization_consequence_guide) if organization_consequence_guide
-    true
   end
 
   def set_sort_key

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -60,7 +60,7 @@ class Project < ApplicationRecord
   end
 
   def consequence_guide?
-    @has_consequence_guide = organization_consequence_guide.present?
+    @has_consequence_guide = organization_consequence_guide.consequences.any?
     @has_consequence_guide ||= consequence_guide.consequences.any?
   end
 
@@ -189,7 +189,9 @@ class Project < ApplicationRecord
   private
 
   def create_consequence_guide
-    ConsequenceGuide.create(project_id: id)
+    guide = ConsequenceGuide.create(project_id: id)
+    guide.clone_from(organization.consequence_guide) if self.organization
+    true
   end
 
   def set_sort_key

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -85,8 +85,7 @@ class Project < ApplicationRecord
   end
 
   def organization_consequence_guide
-    return unless organization
-    organization.consequence_guide
+    @organization_consequence_guide ||= organization && organization.consequence_guide
   end
 
   def organization_moderators
@@ -190,7 +189,7 @@ class Project < ApplicationRecord
 
   def create_consequence_guide
     guide = ConsequenceGuide.create(project_id: id)
-    guide.clone_from(organization.consequence_guide) if self.organization
+    guide.clone_from(organization_consequence_guide) if organization_consequence_guide
     true
   end
 

--- a/spec/features/organization_spec.rb
+++ b/spec/features/organization_spec.rb
@@ -119,7 +119,9 @@ describe "organization management", type: :feature do
       select "Umbrella Corporation", from: "project_organization_id"
       click_on("Create Project")
       expect(page).to have_content("Umbrella Corporation: My Project 1")
-      expect(Project.last.organization_id).to eq(organization.id)
+      project = Project.last
+      expect(project.organization_id).to eq(organization.id)
+      expect(project.consequence_guide.consequences.first).to eq(organization.consequence_guide.consequences.first)
     end
 
     it "lets an owner edit an organization" do


### PR DESCRIPTION
## Problem
When an organization project is created, the check for whether the project has a complete consequence guide returns true if there is an organization consequence guide. See issue #254 

## Solution
Fix the `consequence_guide?` method to look for project-scoped consequences.

## Notes for Reviewers
Anything that you want to tell the people who are going to review your pull request.

## Checklist
- [ ] Reasonable and adequate test coverage
- [ ] Requires a database migration
- [ ] Any new permissions are present in `app/models/concerns/permissions.rb`
- [ ] Any new environment variables are documented and added to `.env.development.example`
